### PR TITLE
[Feat] #12 - SetUserIdView 및 userId 유효성 로직 구현

### DIFF
--- a/Treehouse/Treehouse.xcodeproj/project.pbxproj
+++ b/Treehouse/Treehouse.xcodeproj/project.pbxproj
@@ -26,6 +26,8 @@
 		00CF35BB2BC306D500D9E332 /* SVGKitSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 00CF35BA2BC306D500D9E332 /* SVGKitSwift */; };
 		00CF35CB2BC3083100D9E332 /* String+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00CF35CA2BC3083100D9E332 /* String+.swift */; };
 		3FBFBA802BC3DA6C00B6A446 /* View+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FBFBA7F2BC3DA6C00B6A446 /* View+.swift */; };
+		3FE00F0E2BC6D35A00CC821E /* SetUserIdView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FE00F0D2BC6D35A00CC821E /* SetUserIdView.swift */; };
+		3FE00F102BC7E29700CC821E /* TextFieldStateType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FE00F0F2BC7E29700CC821E /* TextFieldStateType.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -42,6 +44,8 @@
 		00CF35CA2BC3083100D9E332 /* String+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+.swift"; sourceTree = "<group>"; };
 		3FBFBA7E2BC3C1A100B6A446 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		3FBFBA7F2BC3DA6C00B6A446 /* View+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+.swift"; sourceTree = "<group>"; };
+		3FE00F0D2BC6D35A00CC821E /* SetUserIdView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetUserIdView.swift; sourceTree = "<group>"; };
+		3FE00F0F2BC7E29700CC821E /* TextFieldStateType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFieldStateType.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -147,6 +151,7 @@
 		00CF359A2BC2E2FF00D9E332 /* Auth */ = {
 			isa = PBXGroup;
 			children = (
+				3FE00F0F2BC7E29700CC821E /* TextFieldStateType.swift */,
 				00CF359D2BC2F21400D9E332 /* RegisterScene */,
 			);
 			path = Auth;
@@ -156,6 +161,7 @@
 			isa = PBXGroup;
 			children = (
 				00CF35832BC291FA00D9E332 /* ContentView.swift */,
+				3FE00F0D2BC6D35A00CC821E /* SetUserIdView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -275,12 +281,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				00CF35982BC2E22200D9E332 /* SizeLiterals.swift in Sources */,
+				3FE00F0E2BC6D35A00CC821E /* SetUserIdView.swift in Sources */,
 				00CF35962BC2E21700D9E332 /* FontLiterals.swift in Sources */,
 				00CF35942BC2E20300D9E332 /* StringLiterals.swift in Sources */,
 				00CF35842BC291FA00D9E332 /* ContentView.swift in Sources */,
 				00CF35822BC291FA00D9E332 /* TreehouseApp.swift in Sources */,
 				00CF35CB2BC3083100D9E332 /* String+.swift in Sources */,
 				3FBFBA802BC3DA6C00B6A446 /* View+.swift in Sources */,
+				3FE00F102BC7E29700CC821E /* TextFieldStateType.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Treehouse/Treehouse/Global/Literals/StringLiterals.swift
+++ b/Treehouse/Treehouse/Global/Literals/StringLiterals.swift
@@ -32,9 +32,10 @@ enum StringLiterals {
         
         static let indicatorTitle1 = "전화번호 구조가 맞지 않습니다."
         static let indicatorTitle2 = "인증번호가 맞지 않습니다."
+        static let indicatorTitle3 = "*이름 양식과 맞지 않습니다.(숫자, 소문자 영어, _, . 사용 가능)"
         
         static let placeholderTitle1 = "전화번호 입력"
-        static let placeholderTitle2 = "유저 이름 입력"
+        static let placeholderTitle2 = "유저이름 입력"
         static let placeholderTitle3 = "멤버 이름 입력"
         static let placeholderTitle4 = "바이오 입력"
         

--- a/Treehouse/Treehouse/Presentation/Auth/RegisterScene/Views/SetUserIdView.swift
+++ b/Treehouse/Treehouse/Presentation/Auth/RegisterScene/Views/SetUserIdView.swift
@@ -1,0 +1,121 @@
+//
+//  SetUserIdView.swift
+//  Treehouse
+//
+//  Created by ParkJunHyuk on 4/10/24.
+//
+
+import SwiftUI
+
+enum SetUserIdField {
+    case userId
+}
+
+struct SetUserIdView: View {
+    
+    // MARK: - State Property
+    
+    @State var userId: String = ""
+    @State var isButtonEnabled: Bool = false
+    @State var textFieldState: TextFieldStateType = .notFocused
+    @FocusState private var focusedField: SetUserIdField?
+    
+    // MARK: - View
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            VStack(alignment: .leading, spacing: 24) {
+                Text(StringLiterals.Register.registerTitle4)
+                    .fontWithLineHeight(fontLevel: .heading1)
+                    .foregroundStyle(.black)
+                
+                Text(StringLiterals.Register.guidanceTitle3)
+                    .fontWithLineHeight(fontLevel: .body3)
+                    .foregroundStyle(.gray5)
+            }
+            .padding(.leading, 2)
+            .padding(.bottom, 26)
+            
+            userNameTextField
+            
+            Spacer()
+            
+            Button(action: {
+                
+            }) {
+                Text(StringLiterals.Register.buttonTitle5)
+                    .padding()
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 56)
+                    .foregroundStyle(isButtonEnabled ? .gray1 : .gray6)
+                    .background(isButtonEnabled ? .treeBlack : .gray2)
+                    .cornerRadius(10)
+            }
+        }
+        .padding(EdgeInsets(top: 66, leading: 22, bottom: 23, trailing: 22))
+        .onAppear {
+            UITextField.appearance().clearButtonMode = .whileEditing
+        }
+        .onChange(of: userId) { _, newValue in
+            if isValidInputUserId(newValue) {
+                isButtonEnabled = true
+                textFieldState = .enable
+            } else {
+                isButtonEnabled = false
+                textFieldState = .unable
+            }
+        }
+        .onChange(of: focusedField) { _, newValue in
+            if newValue == .userId {
+                textFieldState = .enable
+            } else {
+                textFieldState = .notFocused
+            }
+        }
+    }
+}
+
+// MARK: - ViewBuilder
+
+private extension SetUserIdView {
+    @ViewBuilder
+    var userNameTextField: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            TextField(StringLiterals.Register.placeholderTitle2, text: $userId)
+                .fontWithLineHeight(fontLevel: .body2)
+                .foregroundStyle(.gray8)
+                .focused($focusedField, equals: .userId)
+                .padding(EdgeInsets(top: 18, leading: 18, bottom: 18, trailing: 10))
+                .frame(height: 62)
+                .background(textFieldState.backgroundColor)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12)
+                        .stroke(textFieldState.borderColor, lineWidth: 1.5)
+                )
+                .cornerRadius(12)
+            
+            if textFieldState == .unable {
+                Text(StringLiterals.Register.indicatorTitle3)
+                    .fontWithLineHeight(fontLevel: .caption1)
+                    .foregroundStyle(.error)
+            }
+        }
+    }
+}
+
+// MARK: - Func
+
+private extension SetUserIdView {
+    // 입력값이 주어진 조건을 충족하는지 여부를 확인하는 정규식 ( 0~9,a~z, _, ., 4~20자 )
+    func isValidInputUserId(_ input: String) -> Bool {
+        let regex = try! NSRegularExpression(pattern: "^[0-9a-z_\\.]{4,20}$")
+        let range = NSRange(location: 0, length: input.utf16.count)
+        return regex.firstMatch(in: input, options: [], range: range) != nil
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    SetUserIdView()
+}

--- a/Treehouse/Treehouse/Presentation/Auth/RegisterScene/Views/SetUserIdView.swift
+++ b/Treehouse/Treehouse/Presentation/Auth/RegisterScene/Views/SetUserIdView.swift
@@ -84,6 +84,7 @@ private extension SetUserIdView {
             TextField(StringLiterals.Register.placeholderTitle2, text: $userId)
                 .fontWithLineHeight(fontLevel: .body2)
                 .foregroundStyle(.gray8)
+                .tint(.treeGreen)
                 .focused($focusedField, equals: .userId)
                 .padding(EdgeInsets(top: 18, leading: 18, bottom: 18, trailing: 10))
                 .frame(height: 62)

--- a/Treehouse/Treehouse/Presentation/Auth/TextFieldStateType.swift
+++ b/Treehouse/Treehouse/Presentation/Auth/TextFieldStateType.swift
@@ -1,0 +1,34 @@
+//
+//  TextFieldStateType.swift
+//  Treehouse
+//
+//  Created by ParkJunHyuk on 4/11/24.
+//
+
+import SwiftUI
+
+enum TextFieldStateType {
+    case notFocused
+    case enable
+    case unable
+    
+    var borderColor: Color {
+        switch self {
+        case .notFocused:
+            return .gray1
+        case .enable:
+            return .gray8
+        case .unable:
+            return .error
+        }
+    }
+    
+    var backgroundColor: Color {
+        switch self {
+        case .notFocused:
+            return .gray1
+        case .enable, .unable:
+            return .white
+        }
+    }
+}


### PR DESCRIPTION
## 📟 관련 이슈
- Resolved: #12 

## 👷 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
- SetUserIdView 구현
- StringLiterals 추가 및 수정
- TextfieldStateType Enum 구현

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "https://github.com/Team-Shaka/Tree-House-iOS/assets/45564605/f5861779-1f42-42bf-b812-f0f19bd8b046" width ="250">|

## 🖥️ 주요 코드
`TextFieldStateType`

- TextField 의 여러 상태를 미리 enum 으로 구현했습니다.

``` swift
enum TextFieldStateType {
    case notFocused
    case enable
    case unable
    
    var borderColor: Color {
        switch self {
        case .notFocused:
            return .gray1
        case .enable:
            return .gray8
        case .unable:
            return .error
        }
    }
    
    var backgroundColor: Color {
        switch self {
        case .notFocused:
            return .gray1
        case .enable, .unable:
            return .white
        }
    }
}
```
`SetUserIdView`

- TextField 에 입력된 값을 없애주는 x 버튼을 추가할 수 있습니다.

``` swift
.onAppear {
    UITextField.appearance().clearButtonMode = .whileEditing
}
```

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
