### PR TITLE
[Feat] #19 - 회원가입 뷰 텍스트 행간 높이 조정

### DIFF
--- a/Treehouse/Treehouse/Presentation/Auth/RegisterScene/Views/LoginView.swift
+++ b/Treehouse/Treehouse/Presentation/Auth/RegisterScene/Views/LoginView.swift
@@ -15,14 +15,14 @@ struct LoginView: View {
         VStack(spacing: 0) {
             VStack(alignment: .leading, spacing: 0) {
                 Text(StringLiterals.Register.registerTitle3)
-                    .font(.fontGuide(.heading1))
+                    .fontWithLineHeight(fontLevel: .heading1)
                     .foregroundStyle(.treeBlack)
                     .frame(width: 287, height: 108)
                 
                 Spacer(minLength: SizeLiterals.Screen.screenHeight * 24 / 852)
                 
                 Text(StringLiterals.Register.guidanceTitle2)
-                    .font(.fontGuide(.body1))
+                    .fontWithLineHeight(fontLevel: .body1)
                     .foregroundStyle(.gray5)
                     .frame(height: 78)
             }
@@ -44,7 +44,7 @@ struct LoginView: View {
                 print("로그인 버튼 탭했음")
             } label: {
                 Text("로그인")
-                    .font(.fontGuide(.body2))
+                    .fontWithLineHeight(fontLevel: .body2)
                     .foregroundStyle(.gray1)
                     .frame(width: SizeLiterals.Screen.screenWidth * 344 / 393, height: 56)
                     .background(.treeBlack)

--- a/Treehouse/Treehouse/Presentation/Auth/RegisterScene/Views/UnableRegisterView.swift
+++ b/Treehouse/Treehouse/Presentation/Auth/RegisterScene/Views/UnableRegisterView.swift
@@ -20,14 +20,14 @@ struct UnableRegisterView: View {
                 Spacer(minLength: SizeLiterals.Screen.screenHeight * 28 / 852)
                 
                 Text(StringLiterals.Register.registerTitle2)
-                    .font(.fontGuide(.heading1))
+                    .fontWithLineHeight(fontLevel: .heading1)
                     .foregroundStyle(.treeBlack)
                     .frame(width: 335, height: 72)
                 
                 Spacer(minLength: SizeLiterals.Screen.screenHeight * 24 / 852)
                 
                 Text(StringLiterals.Register.guidanceTitle2)
-                    .font(.fontGuide(.body1))
+                    .fontWithLineHeight(fontLevel: .body1)
                     .foregroundStyle(.gray5)
                     .frame(height: 78)
             }
@@ -36,7 +36,7 @@ struct UnableRegisterView: View {
             Spacer(minLength: SizeLiterals.Screen.screenHeight * 269 / 852)
             
             Text(StringLiterals.Register.etcTitle1)
-                .font(.fontGuide(.body1))
+                .fontWithLineHeight(fontLevel: .body1)
                 .foregroundStyle(.treeGreen)
                 .frame(maxWidth: .infinity)
                 .frame(height: 70)

--- a/Treehouse/Treehouse/Presentation/Auth/RegisterScene/Views/VerificationView.swift
+++ b/Treehouse/Treehouse/Presentation/Auth/RegisterScene/Views/VerificationView.swift
@@ -16,7 +16,7 @@ struct VerificationView: View {
     // MARK: - State Property
     
     @State private var verificationCode: String = ""
-    @State private var isValid = true
+    @State private var isValid = false
     @FocusState private var isKeyboardShowing: Bool
     
     // MARK: - View
@@ -26,17 +26,16 @@ struct VerificationView: View {
             VStack(alignment: .leading, spacing: 0) {
                 HStack(spacing: 0) {
                     Text("\(phoneNumber ?? "nil")")
-                        .font(.fontGuide(.heading1))
                         .foregroundStyle(.treeGreen)
                     +
                     Text("로 전송된\n6자리 인증번호를 입력해주세요.")
-                        .font(.fontGuide(.heading1))
                         .foregroundStyle(.treeBlack)
                 }
+                .fontWithLineHeight(fontLevel: .heading1)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .frame(height: 72)
                 
-                Spacer(minLength: SizeLiterals.Screen.screenHeight * 50 / 852)
+                Spacer(minLength: SizeLiterals.Screen.screenHeight * 40 / 852)
                 
                 HStack(spacing: 0) {
                     ForEach(0 ..< 6, id: \.self) {index in
@@ -59,22 +58,23 @@ struct VerificationView: View {
                 .padding(.bottom, 20)
                 .padding(.top, 10)
                 
-                Spacer(minLength: SizeLiterals.Screen.screenHeight * 8 / 852)
+                Spacer(minLength: SizeLiterals.Screen.screenHeight * 3 / 852)
                 
                 Text("*인증번호가 맞지 않습니다.")
-                    .font(.fontGuide(.caption1))
+                    .fontWithLineHeight(fontLevel: .caption1)
                     .foregroundStyle(isValid ? .grayscaleWhite : .error)
+                    .offset(y: -SizeLiterals.Screen.screenHeight * 10 / 852)
                 
-                Spacer(minLength: SizeLiterals.Screen.screenHeight * 24 / 852)
+                Spacer(minLength: SizeLiterals.Screen.screenHeight * 20 / 852)
                 
                 Text(StringLiterals.Register.guidanceTitle1)
-                    .font(.fontGuide(.body5))
+                    .fontWithLineHeight(fontLevel: .body5)
                     .foregroundStyle(.gray5)
-                    .frame(height: 60)
+                    .frame(height: 72)
             }
             .padding(.top, SizeLiterals.Screen.screenHeight * 66 / 852)
             
-            Spacer(minLength: SizeLiterals.Screen.screenHeight * 335 / 852)
+            Spacer(minLength: SizeLiterals.Screen.screenHeight * 325 / 852)
             
             Button {
                 print("다음으로 버튼 탭했음")


### PR DESCRIPTION
## 📟 관련 이슈
- Resolved: #19 

## 👷 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
- 인증번호 입력 뷰 텍스트 행간 높이 조정
- 회원가입 불가 뷰 텍스트 행간 높이 조정
- 로그인 뷰 텍스트 행간 높이 조정 

## 🚨 참고 사항
<!-- 참고 사항을 적어주세요. 없으면 지워주세요. -->
없습니다.

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|인증번호 입력|<img src = "https://github.com/Team-Shaka/Tree-House-iOS/assets/124351800/f10914c9-99d7-4b6e-b2ed-d9b3560149c8" width ="250">|
|회원가입 불가|<img src = "https://github.com/Team-Shaka/Tree-House-iOS/assets/124351800/a55087f8-7f3e-4876-86ba-d551b1aad436" width ="250">|
|로그인|<img src = "https://github.com/Team-Shaka/Tree-House-iOS/assets/124351800/f3b99050-a556-4cc8-a711-bbe58b114c75" width ="250">|

## 📂 참고한 내용
<!— 참고한 사이트나 정보가 있다면 작성주세요 —>
행간 높이 조정 Reference: https://github.com/Team-Shaka/Tree-House-iOS/pull/9

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
