### PR TITLE
[Feat] #47 - Feed API 기본 세팅 구현

### DIFF
--- a/Treehouse/Treehouse.xcodeproj/project.pbxproj
+++ b/Treehouse/Treehouse.xcodeproj/project.pbxproj
@@ -43,6 +43,20 @@
 		00CF35CB2BC3083100D9E332 /* String+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00CF35CA2BC3083100D9E332 /* String+.swift */; };
 		00F8BB432BC932F000B23AE4 /* UnableRegisterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00F8BB422BC932F000B23AE4 /* UnableRegisterView.swift */; };
 		00F8BB452BC9A43000B23AE4 /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00F8BB442BC9A43000B23AE4 /* LoginView.swift */; };
+		3F06C2F82BFDC2DF002B771B /* FeedService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F06C2F72BFDC2DF002B771B /* FeedService.swift */; };
+		3F06C2FA2BFDC2E8002B771B /* FeedAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F06C2F92BFDC2E8002B771B /* FeedAPI.swift */; };
+		3F06C2FD2BFDD5FD002B771B /* PostCreateFeedPostsRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F06C2FC2BFDD5FD002B771B /* PostCreateFeedPostsRequestDTO.swift */; };
+		3F06C2FF2BFDEA7D002B771B /* PostCreateCommentRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F06C2FE2BFDEA7D002B771B /* PostCreateCommentRequestDTO.swift */; };
+		3F06C3012BFDEAB3002B771B /* PostReportFeedPostRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F06C3002BFDEAB3002B771B /* PostReportFeedPostRequestDTO.swift */; };
+		3F06C3032BFDEAEE002B771B /* PostReportFeedCommentRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F06C3022BFDEAEE002B771B /* PostReportFeedCommentRequestDTO.swift */; };
+		3F06C3052BFDEB1E002B771B /* PostReactionFeedPostRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F06C3042BFDEB1E002B771B /* PostReactionFeedPostRequestDTO.swift */; };
+		3F06C3072BFDEB40002B771B /* PostReactionCommentRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F06C3062BFDEB40002B771B /* PostReactionCommentRequestDTO.swift */; };
+		3F06C30A2BFDEF3F002B771B /* PostCreateFeedPostsResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F06C3092BFDEF3F002B771B /* PostCreateFeedPostsResponseDTO.swift */; };
+		3F06C30C2BFDEFD5002B771B /* GetReadFeedPostsListResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F06C30B2BFDEFD5002B771B /* GetReadFeedPostsListResponseDTO.swift */; };
+		3F06C30E2BFDF16B002B771B /* GetReadDetailFeedPostsResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F06C30D2BFDF16B002B771B /* GetReadDetailFeedPostsResponseDTO.swift */; };
+		3F06C3102BFDF2D4002B771B /* PatchUpdateFeedPostResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F06C30F2BFDF2D4002B771B /* PatchUpdateFeedPostResponseDTO.swift */; };
+		3F06C3122BFDF320002B771B /* PostCreateCommentResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F06C3112BFDF320002B771B /* PostCreateCommentResponseDTO.swift */; };
+		3F06C3142BFDF34C002B771B /* GetReadCommentResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F06C3132BFDF34C002B771B /* GetReadCommentResponseDTO.swift */; };
 		3F2DB2792BCFF5FE00DEFBA6 /* ReceivedInvitationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F2DB2782BCFF5FE00DEFBA6 /* ReceivedInvitationView.swift */; };
 		3F2DB27B2BD0C83900DEFBA6 /* InvitationAlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F2DB27A2BD0C83900DEFBA6 /* InvitationAlertView.swift */; };
 		3F2DB27D2BD0F35900DEFBA6 /* InvitationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F2DB27C2BD0F35900DEFBA6 /* InvitationView.swift */; };
@@ -128,6 +142,20 @@
 		00CF35CA2BC3083100D9E332 /* String+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+.swift"; sourceTree = "<group>"; };
 		00F8BB422BC932F000B23AE4 /* UnableRegisterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnableRegisterView.swift; sourceTree = "<group>"; };
 		00F8BB442BC9A43000B23AE4 /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
+		3F06C2F72BFDC2DF002B771B /* FeedService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedService.swift; sourceTree = "<group>"; };
+		3F06C2F92BFDC2E8002B771B /* FeedAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedAPI.swift; sourceTree = "<group>"; };
+		3F06C2FC2BFDD5FD002B771B /* PostCreateFeedPostsRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCreateFeedPostsRequestDTO.swift; sourceTree = "<group>"; };
+		3F06C2FE2BFDEA7D002B771B /* PostCreateCommentRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCreateCommentRequestDTO.swift; sourceTree = "<group>"; };
+		3F06C3002BFDEAB3002B771B /* PostReportFeedPostRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostReportFeedPostRequestDTO.swift; sourceTree = "<group>"; };
+		3F06C3022BFDEAEE002B771B /* PostReportFeedCommentRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostReportFeedCommentRequestDTO.swift; sourceTree = "<group>"; };
+		3F06C3042BFDEB1E002B771B /* PostReactionFeedPostRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostReactionFeedPostRequestDTO.swift; sourceTree = "<group>"; };
+		3F06C3062BFDEB40002B771B /* PostReactionCommentRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostReactionCommentRequestDTO.swift; sourceTree = "<group>"; };
+		3F06C3092BFDEF3F002B771B /* PostCreateFeedPostsResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCreateFeedPostsResponseDTO.swift; sourceTree = "<group>"; };
+		3F06C30B2BFDEFD5002B771B /* GetReadFeedPostsListResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetReadFeedPostsListResponseDTO.swift; sourceTree = "<group>"; };
+		3F06C30D2BFDF16B002B771B /* GetReadDetailFeedPostsResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetReadDetailFeedPostsResponseDTO.swift; sourceTree = "<group>"; };
+		3F06C30F2BFDF2D4002B771B /* PatchUpdateFeedPostResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PatchUpdateFeedPostResponseDTO.swift; sourceTree = "<group>"; };
+		3F06C3112BFDF320002B771B /* PostCreateCommentResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCreateCommentResponseDTO.swift; sourceTree = "<group>"; };
+		3F06C3132BFDF34C002B771B /* GetReadCommentResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetReadCommentResponseDTO.swift; sourceTree = "<group>"; };
 		3F2DB2782BCFF5FE00DEFBA6 /* ReceivedInvitationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceivedInvitationView.swift; sourceTree = "<group>"; };
 		3F2DB27A2BD0C83900DEFBA6 /* InvitationAlertView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvitationAlertView.swift; sourceTree = "<group>"; };
 		3F2DB27C2BD0F35900DEFBA6 /* InvitationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvitationView.swift; sourceTree = "<group>"; };
@@ -310,6 +338,7 @@
 				0087C28A2BDED554004CED9C /* Register */,
 				3FF106F72BEA074800C52908 /* Invitation */,
 				3FF106F82BEA074E00C52908 /* Notification */,
+				3F06C2F52BFDC2B9002B771B /* Feed */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -495,6 +524,51 @@
 				3F8835842BCC00D30021C8AB /* TextField+.swift */,
 			);
 			path = Extension;
+			sourceTree = "<group>";
+		};
+		3F06C2F52BFDC2B9002B771B /* Feed */ = {
+			isa = PBXGroup;
+			children = (
+				3F06C2F92BFDC2E8002B771B /* FeedAPI.swift */,
+				3F06C2F72BFDC2DF002B771B /* FeedService.swift */,
+				3F06C2F62BFDC2CF002B771B /* DTO */,
+			);
+			path = Feed;
+			sourceTree = "<group>";
+		};
+		3F06C2F62BFDC2CF002B771B /* DTO */ = {
+			isa = PBXGroup;
+			children = (
+				3F06C2FB2BFDD5BD002B771B /* Request */,
+				3F06C3082BFDEF18002B771B /* Response */,
+			);
+			path = DTO;
+			sourceTree = "<group>";
+		};
+		3F06C2FB2BFDD5BD002B771B /* Request */ = {
+			isa = PBXGroup;
+			children = (
+				3F06C2FC2BFDD5FD002B771B /* PostCreateFeedPostsRequestDTO.swift */,
+				3F06C2FE2BFDEA7D002B771B /* PostCreateCommentRequestDTO.swift */,
+				3F06C3002BFDEAB3002B771B /* PostReportFeedPostRequestDTO.swift */,
+				3F06C3022BFDEAEE002B771B /* PostReportFeedCommentRequestDTO.swift */,
+				3F06C3042BFDEB1E002B771B /* PostReactionFeedPostRequestDTO.swift */,
+				3F06C3062BFDEB40002B771B /* PostReactionCommentRequestDTO.swift */,
+			);
+			path = Request;
+			sourceTree = "<group>";
+		};
+		3F06C3082BFDEF18002B771B /* Response */ = {
+			isa = PBXGroup;
+			children = (
+				3F06C3092BFDEF3F002B771B /* PostCreateFeedPostsResponseDTO.swift */,
+				3F06C30B2BFDEFD5002B771B /* GetReadFeedPostsListResponseDTO.swift */,
+				3F06C30D2BFDF16B002B771B /* GetReadDetailFeedPostsResponseDTO.swift */,
+				3F06C30F2BFDF2D4002B771B /* PatchUpdateFeedPostResponseDTO.swift */,
+				3F06C3112BFDF320002B771B /* PostCreateCommentResponseDTO.swift */,
+				3F06C3132BFDF34C002B771B /* GetReadCommentResponseDTO.swift */,
+			);
+			path = Response;
 			sourceTree = "<group>";
 		};
 		3F8835862BCC05540021C8AB /* ViewModifier */ = {
@@ -847,12 +921,18 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3F06C30E2BFDF16B002B771B /* GetReadDetailFeedPostsResponseDTO.swift in Sources */,
+				3F06C3072BFDEB40002B771B /* PostReactionCommentRequestDTO.swift in Sources */,
+				3F06C2FA2BFDC2E8002B771B /* FeedAPI.swift in Sources */,
 				3F88357B2BC8E1010021C8AB /* ReceivedFirstInvitaionView.swift in Sources */,
 				944AA7162BCBB145008020C2 /* ShowMemberProfileView.swift in Sources */,
 				3FE944152BD63FF600C3A869 /* ReceivedInvitationViewModel.swift in Sources */,
+				3F06C30C2BFDEFD5002B771B /* GetReadFeedPostsListResponseDTO.swift in Sources */,
+				3F06C3052BFDEB1E002B771B /* PostReactionFeedPostRequestDTO.swift in Sources */,
 				00CF35982BC2E22200D9E332 /* SizeLiterals.swift in Sources */,
 				944AA7122BC6E400008020C2 /* SetPhoneNumberView.swift in Sources */,
 				3FF1071B2BEA0A4600C52908 /* PostRegisterUserRequestDTO.swift in Sources */,
+				3F06C30A2BFDEF3F002B771B /* PostCreateFeedPostsResponseDTO.swift in Sources */,
 				3FC1FB2E2BD7739800AAE53F /* FeedContentViewModel.swift in Sources */,
 				0012366D2BCED9BD00CEAC53 /* GreenLetterView.swift in Sources */,
 				3F8835852BCC00D30021C8AB /* TextField+.swift in Sources */,
@@ -867,8 +947,10 @@
 				9445620A2BD185A600078023 /* NotificationView.swift in Sources */,
 				0087C29E2BE360A6004CED9C /* RegisterService.swift in Sources */,
 				3F8835832BCBF97D0021C8AB /* SetMemberBioView.swift in Sources */,
+				3F06C3102BFDF2D4002B771B /* PatchUpdateFeedPostResponseDTO.swift in Sources */,
 				00CF35942BC2E20300D9E332 /* StringLiterals.swift in Sources */,
 				3FE944122BD3ADFF00C3A869 /* ReceivedInvitationModel.swift in Sources */,
+				3F06C3032BFDEAEE002B771B /* PostReportFeedCommentRequestDTO.swift in Sources */,
 				3F2DB27D2BD0F35900DEFBA6 /* InvitationView.swift in Sources */,
 				3FF106FC2BEA078D00C52908 /* BaseResponse.swift in Sources */,
 				3FF1071D2BEA0A5300C52908 /* PostReissueTokenRequestDTO.swift in Sources */,
@@ -889,6 +971,9 @@
 				3FE944172BD645C300C3A869 /* ReceivedInvitationRowView.swift in Sources */,
 				3FF107172BEA0A2A00C52908 /* PostCheckUserNameRequestDTO.swift in Sources */,
 				0087C29C2BE3609C004CED9C /* RegisterAPI.swift in Sources */,
+				3F06C2FF2BFDEA7D002B771B /* PostCreateCommentRequestDTO.swift in Sources */,
+				3F06C3012BFDEAB3002B771B /* PostReportFeedPostRequestDTO.swift in Sources */,
+				3F06C3122BFDF320002B771B /* PostCreateCommentResponseDTO.swift in Sources */,
 				005296C42BD6AABF007D209A /* DarkGreenLetterView.swift in Sources */,
 				9449C6D22BDBA87400FC938B /* FeedView.swift in Sources */,
 				001236732BD2748200CEAC53 /* PhoneNumberRow.swift in Sources */,
@@ -899,12 +984,14 @@
 				3FE00F122BC8138300CC821E /* ShowUserProfileView.swift in Sources */,
 				003E6EF42BD5105A001C7613 /* AvailableInvitationStruct.swift in Sources */,
 				944D48912BF10B6700205B18 /* GetCheckNotificationsResponseDTO.swift in Sources */,
+				3F06C3142BFDF34C002B771B /* GetReadCommentResponseDTO.swift in Sources */,
 				3FF107272BEA0ACC00C52908 /* PostReissueTokenResponseDTO.swift in Sources */,
 				3FF107252BEA0AB600C52908 /* PostRegisterUserResponseDTO.swift in Sources */,
 				0087C29A2BE161C9004CED9C /* PostCheckNameUseCase.swift in Sources */,
 				3FF107082BEA086900C52908 /* GetCheckInvitationsReponseDTO.swift in Sources */,
 				0012366B2BCEBBAA00CEAC53 /* InviteBranchView.swift in Sources */,
 				00CF35CB2BC3083100D9E332 /* String+.swift in Sources */,
+				3F06C2FD2BFDD5FD002B771B /* PostCreateFeedPostsRequestDTO.swift in Sources */,
 				3FF1071F2BEA0A7D00C52908 /* PostAcceptInvitationTreeMemberResponseDTO.swift in Sources */,
 				00F8BB452BC9A43000B23AE4 /* LoginView.swift in Sources */,
 				3FF106FA2BEA077E00C52908 /* BaseRequest.swift in Sources */,
@@ -919,6 +1006,7 @@
 				3FF107022BEA07FB00C52908 /* InvitationAPI.swift in Sources */,
 				3FF1072B2BEA0BE700C52908 /* Config.swift in Sources */,
 				3FF107062BEA083D00C52908 /* GetCheckAvailableInvitationResponseDTO.swift in Sources */,
+				3F06C2F82BFDC2DF002B771B /* FeedService.swift in Sources */,
 				0087C2872BDEC7B0004CED9C /* DefaultRegisterRepository.swift in Sources */,
 				3FE00F102BC7E29700CC821E /* TextFieldStateType.swift in Sources */,
 				944D48952BF10CA000205B18 /* SinglePostView.swift in Sources */,

--- a/Treehouse/Treehouse/Network/Feed/DTO/Request/PostCreateCommentRequestDTO.swift
+++ b/Treehouse/Treehouse/Network/Feed/DTO/Request/PostCreateCommentRequestDTO.swift
@@ -1,0 +1,12 @@
+//
+//  PostCreateCommentRequestDTO.swift
+//  Treehouse
+//
+//  Created by ParkJunHyuk on 5/22/24.
+//
+
+import Foundation
+
+struct PostCreateCommentRequestDTO: Codable {
+    let centext: String
+}

--- a/Treehouse/Treehouse/Network/Feed/DTO/Request/PostCreateFeedPostsRequestDTO.swift
+++ b/Treehouse/Treehouse/Network/Feed/DTO/Request/PostCreateFeedPostsRequestDTO.swift
@@ -1,0 +1,13 @@
+//
+//  PostCreateFeedPostsRequestDTO.swift
+//  Treehouse
+//
+//  Created by ParkJunHyuk on 5/22/24.
+//
+
+import Foundation
+
+struct PostCreateFeedPostsRequestDTO: Codable {
+    let context: String
+    let pictureUrlList: [String]
+}

--- a/Treehouse/Treehouse/Network/Feed/DTO/Request/PostReactionCommentRequestDTO.swift
+++ b/Treehouse/Treehouse/Network/Feed/DTO/Request/PostReactionCommentRequestDTO.swift
@@ -1,0 +1,12 @@
+//
+//  PostReactionCommentRequestDTO.swift
+//  Treehouse
+//
+//  Created by ParkJunHyuk on 5/22/24.
+//
+
+import Foundation
+
+struct PostReactionCommentRequestDTO: Codable {
+    let reactionName: String
+}

--- a/Treehouse/Treehouse/Network/Feed/DTO/Request/PostReactionFeedPostRequestDTO.swift
+++ b/Treehouse/Treehouse/Network/Feed/DTO/Request/PostReactionFeedPostRequestDTO.swift
@@ -1,0 +1,12 @@
+//
+//  PostReactionFeedPostRequestDTO.swift
+//  Treehouse
+//
+//  Created by ParkJunHyuk on 5/22/24.
+//
+
+import Foundation
+
+struct PostReactionFeedPostRequestDTO: Codable {
+    let reactionName: String
+}

--- a/Treehouse/Treehouse/Network/Feed/DTO/Request/PostReportFeedCommentRequestDTO.swift
+++ b/Treehouse/Treehouse/Network/Feed/DTO/Request/PostReportFeedCommentRequestDTO.swift
@@ -1,0 +1,13 @@
+//
+//  PostReportFeedCommentRequestDTO.swift
+//  Treehouse
+//
+//  Created by ParkJunHyuk on 5/22/24.
+//
+
+import Foundation
+
+struct PostReportFeedCommentRequestDTO: Codable {
+    let reason: String
+    let targetMemberId: String
+}

--- a/Treehouse/Treehouse/Network/Feed/DTO/Request/PostReportFeedPostRequestDTO.swift
+++ b/Treehouse/Treehouse/Network/Feed/DTO/Request/PostReportFeedPostRequestDTO.swift
@@ -1,0 +1,13 @@
+//
+//  PostReportFeedPostRequestDTO.swift
+//  Treehouse
+//
+//  Created by ParkJunHyuk on 5/22/24.
+//
+
+import Foundation
+
+struct PostReportFeedPostRequestDTO: Codable {
+    let reason: String
+    let targetMemberId: Int
+}

--- a/Treehouse/Treehouse/Network/Feed/DTO/Response/GetReadCommentResponseDTO.swift
+++ b/Treehouse/Treehouse/Network/Feed/DTO/Response/GetReadCommentResponseDTO.swift
@@ -1,0 +1,16 @@
+//
+//  GetReadCommentResponseDTO.swift
+//  Treehouse
+//
+//  Created by ParkJunHyuk on 5/22/24.
+//
+
+import Foundation
+
+struct GetReadCommentResponseDTO: Decodable {
+    let memberProfile: [MemberProfileResponseData]
+    let reactionList: [ReactionListResponseData]
+    let commentId: Int
+    let context: String
+    let commentedAt: String
+}

--- a/Treehouse/Treehouse/Network/Feed/DTO/Response/GetReadDetailFeedPostsResponseDTO.swift
+++ b/Treehouse/Treehouse/Network/Feed/DTO/Response/GetReadDetailFeedPostsResponseDTO.swift
@@ -1,0 +1,17 @@
+//
+//  GetReadDetailFeedPostsResponseDTO.swift
+//  Treehouse
+//
+//  Created by ParkJunHyuk on 5/22/24.
+//
+
+import Foundation
+
+struct GetReadDetailFeedPostsResponseDTO: Decodable {
+    let memberProfile: [MemberProfileResponseData]
+    let postId: Int
+    let context: String
+    let pictureUrlList: [String]
+    let reactionList: [ReactionListResponseData]
+    let postedAt: String
+}

--- a/Treehouse/Treehouse/Network/Feed/DTO/Response/GetReadFeedPostsListResponseDTO.swift
+++ b/Treehouse/Treehouse/Network/Feed/DTO/Response/GetReadFeedPostsListResponseDTO.swift
@@ -1,0 +1,30 @@
+//
+//  GetReadFeedPostsListResponseDTO.swift
+//  Treehouse
+//
+//  Created by ParkJunHyuk on 5/22/24.
+//
+
+import Foundation
+
+struct GetReadFeedPostsListResponseDTO: Decodable {
+    let memberProfile: [MemberProfileResponseData]
+    let postId: Int
+    let context: String
+    let pictureUrlList: [String]
+    let reactionList: [ReactionListResponseData]
+    let postedAt: String
+}
+
+struct MemberProfileResponseData: Decodable {
+    let memberId: Int
+    let memberProfileImageUrl: String
+    let memberName: String
+    let memberBranch: Int
+}
+
+struct ReactionListResponseData: Decodable {
+    let reactionName: String
+    let reactionCount: Int
+    let isPushed: Bool
+}

--- a/Treehouse/Treehouse/Network/Feed/DTO/Response/PatchUpdateFeedPostResponseDTO.swift
+++ b/Treehouse/Treehouse/Network/Feed/DTO/Response/PatchUpdateFeedPostResponseDTO.swift
@@ -1,0 +1,12 @@
+//
+//  PatchUpdateFeedPostResponseDTO.swift
+//  Treehouse
+//
+//  Created by ParkJunHyuk on 5/22/24.
+//
+
+import Foundation
+
+struct PatchUpdateFeedPostResponseDTO: Decodable {
+    let context: String
+}

--- a/Treehouse/Treehouse/Network/Feed/DTO/Response/PostCreateCommentResponseDTO.swift
+++ b/Treehouse/Treehouse/Network/Feed/DTO/Response/PostCreateCommentResponseDTO.swift
@@ -1,0 +1,12 @@
+//
+//  PostCreateCommentResponseDTO.swift
+//  Treehouse
+//
+//  Created by ParkJunHyuk on 5/22/24.
+//
+
+import Foundation
+
+struct PostCreateCommentResponseDTO: Decodable {
+    let postId: Int
+}

--- a/Treehouse/Treehouse/Network/Feed/DTO/Response/PostCreateFeedPostsResponseDTO.swift
+++ b/Treehouse/Treehouse/Network/Feed/DTO/Response/PostCreateFeedPostsResponseDTO.swift
@@ -1,0 +1,12 @@
+//
+//  PostCreateFeedPostsResponseDTO.swift
+//  Treehouse
+//
+//  Created by ParkJunHyuk on 5/22/24.
+//
+
+import Foundation
+
+struct PostCreateFeedPostsResponseDTO: Decodable {
+    let postId: Int
+}

--- a/Treehouse/Treehouse/Network/Feed/FeedAPI.swift
+++ b/Treehouse/Treehouse/Network/Feed/FeedAPI.swift
@@ -1,0 +1,91 @@
+//
+//  FeedAPI.swift
+//  Treehouse
+//
+//  Created by ParkJunHyuk on 5/22/24.
+//
+
+import Foundation
+
+enum FeedAPI {
+    case postCreateFeedPosts(treehouseId: Int, requestBody: PostCreateFeedPostsRequestDTO)
+    case getReadFeedPostsList(treehouseId: Int)
+    case getReadDetailFeedPosts(treehouseId: Int, postId: Int)
+    case patchUpdateFeedPost(treehouseId: Int, postId: Int)
+    case deleteFeedPost(treehouseId: Int, postId: Int)
+    case postCreateComment(treehouseId: Int, postId: Int, requestBody: PostCreateCommentRequestDTO)
+    case getReadComment(treehouseId: Int, postId: Int)
+    case deleteComment(treehouseId: Int, postId: Int, commentId: Int)
+    case postPresignedURL
+    case postReportFeedPost(treehouseId: Int, postId: Int, requestBody: PostReportFeedPostRequestDTO)
+    case postReportFeedComment(treehouseId: Int, postId: Int, commentId: Int, requestBody: PostReportFeedCommentRequestDTO)
+    case postReactionFeedPost(treehouseId: Int, postId: Int, requestBody: PostReactionFeedPostRequestDTO)
+    case postReactionComment(treehouseId: Int, postId: Int, commentId: Int, requestBody: PostReactionCommentRequestDTO)
+}
+
+extension FeedAPI: BaseRequest {
+    var path: String {
+        switch self {
+        case .postCreateFeedPosts(let treehouseId, _):
+            return "/treehouses/\(treehouseId)/feeds/posts"
+        case .getReadFeedPostsList(let treehouseId):
+            return "/treehouses/\(treehouseId)/feeds"
+        case .getReadDetailFeedPosts(let treehouseId, let postId),
+                .patchUpdateFeedPost(let treehouseId, let postId),
+                .deleteFeedPost(let treehouseId, let postId):
+            return "/treehouses/\(treehouseId)/feeds/posts/\(postId)"
+        case .postCreateComment(let treehouseId, let postId, _),
+                .getReadComment(let treehouseId, let postId):
+            return "/treehouses/\(treehouseId)/feeds/posts/\(postId)/comments"
+        case .deleteComment(let treehouseId, let postId, let commentId):
+            return "/treehouses/\(treehouseId)/feeds/posts/\(postId)/comments/\(commentId)"
+        case .postPresignedURL:
+            // MARK: -TODO (postPresignedURL)
+            return ""
+        case .postReportFeedPost(let treehouseId, let postId, _):
+            return "/treehouses/\(treehouseId)/feeds/posts/\(postId)/reports"
+        case .postReportFeedComment(let treehouseId, let postId, let commentId, _):
+            return "/treehouses/\(treehouseId)/feeds/posts/\(postId)/comments/\(commentId)/reports"
+        case .postReactionFeedPost(let treehouseId, let postId, _):
+            return "/treehouses/\(treehouseId)/feeds/posts/\(postId)/reactions"
+        case .postReactionComment(let treehouseId, let postId, let commentId, _):
+            return "/treehouses/\(treehouseId)/feeds/posts/\(postId)/comments/\(commentId)/reactions"
+        }
+    }
+    
+    var httpMethod: HttpMethod {
+        switch self {
+        case .postCreateFeedPosts,.postCreateComment, .postPresignedURL, .postReportFeedPost,
+                .postReportFeedComment, .postReactionFeedPost, .postReactionComment:
+            return .post
+        case .getReadFeedPostsList, .getReadDetailFeedPosts, .getReadComment:
+            return .get
+        case .patchUpdateFeedPost:
+            return .patch
+        case .deleteFeedPost, .deleteComment:
+            return .delete
+        }
+    }
+    
+    var headerType: HeaderType {
+        return .accessTokenHeader
+    }
+    
+    var body: Data? { return .none }
+
+    var queryParameter: [String : Any]? { return .none }
+    
+    var requestBodyParameter: (any Codable)? {
+        switch self {
+        case .postCreateFeedPosts(_ , requestBody: let requestBody): return requestBody
+        case .postCreateComment(_, _, requestBody: let requestBody): return requestBody
+            // MARK: -TODO (postPresignedURL)
+        case .postPresignedURL: return nil
+        case .postReportFeedPost(_, _, requestBody: let requestBody): return requestBody
+        case .postReportFeedComment(_, _, _, requestBody: let requestBody): return requestBody
+        case .postReactionFeedPost(_, _, requestBody: let requestBody): return requestBody
+        case .postReactionComment(_, _, _, requestBody: let requestBody): return requestBody
+        default: return .none
+        }
+    }
+}

--- a/Treehouse/Treehouse/Network/Feed/FeedService.swift
+++ b/Treehouse/Treehouse/Network/Feed/FeedService.swift
@@ -1,0 +1,12 @@
+//
+//  FeedService.swift
+//  Treehouse
+//
+//  Created by ParkJunHyuk on 5/22/24.
+//
+
+import Foundation
+
+final class FeedService {
+    
+}


### PR DESCRIPTION
## 📟 관련 이슈
- Resolved: #47 

## 👷 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
- Feed API 관련 ResponseDTO & RequestDTO 구현
- Feed APIService & Feed API 기본 세팅을 위한 enum 구현

## 🚨 참고 사항
<!-- 참고 사항을 적어주세요. 없으면 지워주세요. -->
- 기존 API 세팅과 동일하게 구현했습니다! , 사용법도 동일한 방법이라고 생각해주시면 좋을거 같아요!
- 다만 서로 다른 API 사이에서 동일한 구조를 가진 DTO 가 존재하여 중복 코드가 발생했습니다.
- 그래도 API 를 사용할때 DTO 와 API 가 동일해야 사용에 큰 지장이 없을거 같아 중복되어도 API 마다 DTO 를 분리했습니다!

## ✅ Checklist
- [X] 필요없는 주석, 프린트문 제거했는지 확인
- [X] 컨벤션 지켰는지 확인
