### PR TITLE
[Feat] #66 - 게시글 및 댓글 바텀시트 구현 / 연결

### DIFF
--- a/Treehouse/Treehouse.xcodeproj/project.pbxproj
+++ b/Treehouse/Treehouse.xcodeproj/project.pbxproj
@@ -176,6 +176,7 @@
 		9499D9522BF1C5AD007CC6CF /* NetworkErrorCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9499D9512BF1C5AD007CC6CF /* NetworkErrorCode.swift */; };
 		9499D9542BF1CA2A007CC6CF /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9499D9532BF1CA2A007CC6CF /* NetworkError.swift */; };
 		9499D9572BF280B8007CC6CF /* NetworkServiceable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9499D9562BF280B8007CC6CF /* NetworkServiceable.swift */; };
+		94C7B4432C2407AD00CA378E /* FeedBottomSheetRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94C7B4422C2407AD00CA378E /* FeedBottomSheetRowView.swift */; };
 		94D100182C0C2A1900025D43 /* CommentCountView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94D100172C0C2A1900025D43 /* CommentCountView.swift */; };
 		94D1001D2C0CC60A00025D43 /* PhotoPickerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94D1001C2C0CC60A00025D43 /* PhotoPickerManager.swift */; };
 /* End PBXBuildFile section */
@@ -345,6 +346,7 @@
 		9499D9512BF1C5AD007CC6CF /* NetworkErrorCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkErrorCode.swift; sourceTree = "<group>"; };
 		9499D9532BF1CA2A007CC6CF /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
 		9499D9562BF280B8007CC6CF /* NetworkServiceable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkServiceable.swift; sourceTree = "<group>"; };
+		94C7B4422C2407AD00CA378E /* FeedBottomSheetRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedBottomSheetRowView.swift; sourceTree = "<group>"; };
 		94D100172C0C2A1900025D43 /* CommentCountView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentCountView.swift; sourceTree = "<group>"; };
 		94D1001C2C0CC60A00025D43 /* PhotoPickerManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoPickerManager.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -1109,6 +1111,7 @@
 				947326182C1C8D640030A182 /* EditPostPopupView.swift */,
 				9473261A2C1D90850030A182 /* ImageDetailCarouselView.swift */,
 				947326222C23F8350030A182 /* DynamicHeightTextEditorView.swift */,
+				94C7B4422C2407AD00CA378E /* FeedBottomSheetRowView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -1294,6 +1297,7 @@
 				3F06C30E2BFDF16B002B771B /* GetReadDetailFeedPostsResponseDTO.swift in Sources */,
 				3FA175D62C1ABDED00A57987 /* PostPresignedURLResponseDTO.swift in Sources */,
 				3FA175DC2C1AC2FD00A57987 /* PresignedURLUseCase.swift in Sources */,
+				94C7B4432C2407AD00CA378E /* FeedBottomSheetRowView.swift in Sources */,
 				3F06C3072BFDEB40002B771B /* PostReactionCommentRequestDTO.swift in Sources */,
 				3FA175E32C1AC47A00A57987 /* PresignedURLResponseEntity.swift in Sources */,
 				3F06C2FA2BFDC2E8002B771B /* FeedAPI.swift in Sources */,

--- a/Treehouse/Treehouse/Presentation/Feed/FeedScene/Views/FeedBottomSheetRowView.swift
+++ b/Treehouse/Treehouse/Presentation/Feed/FeedScene/Views/FeedBottomSheetRowView.swift
@@ -1,0 +1,86 @@
+//
+//  FeedBottomSheetRowView.swift
+//  Treehouse
+//
+//  Created by 윤영서 on 6/20/24.
+//
+
+import SwiftUI
+
+enum FeedBottomSheetCase {
+    case isWriterOnPost
+    case isReaderOnPost
+    case isWriterOnComment
+    case isReaderOnComment
+}
+
+struct FeedBottomSheetRowView: View {
+    
+    // MARK: - Property
+    
+    let sheetCase: FeedBottomSheetCase
+    
+    // MARK: - View
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            RoundedRectangle(cornerRadius: 2.5)
+                .frame(width: 50, height: 4)
+                .foregroundStyle(.gray2)
+                .padding(.top, 10)
+            
+            switch sheetCase {
+            case .isWriterOnPost:
+                BottomSheetButton(imageName: "ic_edit", text: "포스트 수정하기")
+                BottomSheetButton(imageName: "ic_delete", text: "포스트 삭제하기")
+                
+            case .isReaderOnPost:
+                BottomSheetButton(imageName: "ic_report", text: "신고하기", textColor: .red)
+                BottomSheetButton(imageName: "ic_block", text: "해당포스트 차단하기", textColor: .red)
+                
+            case .isWriterOnComment:
+                BottomSheetButton(imageName: "ic_delete", text: "댓글 삭제하기")
+                
+            case .isReaderOnComment:
+                BottomSheetButton(imageName: "ic_report", text: "신고하기", textColor: .red)
+            }
+        }
+        .frame(width: .infinity)
+        .padding(.bottom, 33)
+        .background(.grayscaleWhite)
+        .selectCornerRadius(radius: 20, corners: [.topLeft, .topRight])
+    }
+}
+
+struct BottomSheetButton: View {
+    let imageName: String
+    let text: String
+    var textColor: Color = .treeBlack
+    
+    var body: some View {
+        HStack {
+            Image(imageName)
+                .foregroundColor(textColor)
+            
+            Text(text)
+                .foregroundColor(textColor)
+            
+            Spacer()
+        }
+        .padding(EdgeInsets(top: 12, leading: 16, bottom: 12, trailing: 16))
+    }
+}
+
+// MARK: -Preview
+
+struct FeedBottomSheetRowView_Previews: PreviewProvider {
+    static var previews: some View {
+        Group {
+            FeedBottomSheetRowView(sheetCase: .isWriterOnPost)
+            FeedBottomSheetRowView(sheetCase: .isReaderOnPost)
+            FeedBottomSheetRowView(sheetCase: .isWriterOnComment)
+            FeedBottomSheetRowView(sheetCase: .isReaderOnComment)
+        }
+        .previewLayout(.sizeThatFits)
+    }
+}

--- a/Treehouse/Treehouse/Presentation/Feed/FeedScene/Views/PostDetailView.swift
+++ b/Treehouse/Treehouse/Presentation/Feed/FeedScene/Views/PostDetailView.swift
@@ -56,9 +56,6 @@ struct PostDetailView: View {
                         .foregroundStyle(.treeBlack)
                 }
             }
-            .sheet(isPresented: $isPostEditPopupShowing) {
-                EditPostPopupView()
-            }
         }
     }
 }

--- a/Treehouse/Treehouse/Presentation/Feed/FeedScene/Views/SinglePostView.swift
+++ b/Treehouse/Treehouse/Presentation/Feed/FeedScene/Views/SinglePostView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import PopupView
 
 struct SelectedImage: Identifiable {
     var id: Int
@@ -55,8 +56,6 @@ struct SinglePostView: View {
                         Spacer()
                         
                         Button(action: {
-                            print("meatball button tapped")
-                            // TODO: - Bottom Sheet 연결
                             self.isBottomSheetShowing.toggle()
                         }) {
                             Image(.icMeatball)
@@ -69,8 +68,17 @@ struct SinglePostView: View {
                 }
             }
             .padding(16)
-            
             multipleImagesView
+        }
+        .popup(isPresented: $isBottomSheetShowing) {
+            FeedBottomSheetRowView(sheetCase: .isWriterOnPost)
+        } customize: {
+            $0
+                .type(.toast)
+                .closeOnTapOutside(true)
+                .dragToDismiss(true)
+                .isOpaque(true)
+                .backgroundColor(.treeBlack.opacity(0.5))
         }
     }
 }


### PR DESCRIPTION
## 📟 관련 이슈
- Resolved: #66

## 👷 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
- 바텀시트 케이스별로 enum을 나눠 구현했습니다.
```swift
enum FeedBottomSheetCase {
    case isWriterOnPost
    case isReaderOnPost
    case isWriterOnComment
    case isReaderOnComment
}
```
네가지 케이스 확인 부탁드리며, 사용 시 아래와 같이 사용하면 됩니다.
```swift
 .popup(isPresented: $isBottomSheetShowing) {
            FeedBottomSheetRowView(sheetCase: .isWriterOnPost)
        } customize: {
            $0
                .type(.toast)
                .closeOnTapOutside(true)
                .dragToDismiss(true)
                .isOpaque(true)
                .backgroundColor(.treeBlack.opacity(0.5))
        }
```




## 📸 스크린샷
https://github.com/Team-Shaka/Tree-House-iOS/assets/102219161/75c429f8-9035-41aa-bbcc-36dc6781526a

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
