### PR TITLE
[Feat] #71 - FeedHomeView 화면 전환 및 View 수정

### DIFF
--- a/Treehouse/Treehouse.xcodeproj/project.pbxproj
+++ b/Treehouse/Treehouse.xcodeproj/project.pbxproj
@@ -84,6 +84,9 @@
 		3F2DB2792BCFF5FE00DEFBA6 /* ReceivedInvitationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F2DB2782BCFF5FE00DEFBA6 /* ReceivedInvitationView.swift */; };
 		3F2DB27B2BD0C83900DEFBA6 /* InvitationAlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F2DB27A2BD0C83900DEFBA6 /* InvitationAlertView.swift */; };
 		3F2DB27D2BD0F35900DEFBA6 /* InvitationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F2DB27C2BD0F35900DEFBA6 /* InvitationView.swift */; };
+		3F44C13C2C24394600A5CAFE /* FeedHomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F44C13B2C24394600A5CAFE /* FeedHomeView.swift */; };
+		3F44C13E2C25732E00A5CAFE /* FeedRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F44C13D2C25732E00A5CAFE /* FeedRouter.swift */; };
+		3F44C1402C27E8DD00A5CAFE /* UserInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F44C13F2C27E8DC00A5CAFE /* UserInfoView.swift */; };
 		3F5150442C0D96BE00AD05C3 /* NetworkRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F5150432C0D96BE00AD05C3 /* NetworkRequest.swift */; };
 		3F5150462C0DD47600AD05C3 /* RegisterUserUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F5150452C0DD47600AD05C3 /* RegisterUserUseCase.swift */; };
 		3F5150482C0DD4BB00AD05C3 /* RegisterUserResponseEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F5150472C0DD4BB00AD05C3 /* RegisterUserResponseEntity.swift */; };
@@ -256,6 +259,9 @@
 		3F2DB2782BCFF5FE00DEFBA6 /* ReceivedInvitationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceivedInvitationView.swift; sourceTree = "<group>"; };
 		3F2DB27A2BD0C83900DEFBA6 /* InvitationAlertView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvitationAlertView.swift; sourceTree = "<group>"; };
 		3F2DB27C2BD0F35900DEFBA6 /* InvitationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvitationView.swift; sourceTree = "<group>"; };
+		3F44C13B2C24394600A5CAFE /* FeedHomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedHomeView.swift; sourceTree = "<group>"; };
+		3F44C13D2C25732E00A5CAFE /* FeedRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedRouter.swift; sourceTree = "<group>"; };
+		3F44C13F2C27E8DC00A5CAFE /* UserInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoView.swift; sourceTree = "<group>"; };
 		3F5150432C0D96BE00AD05C3 /* NetworkRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkRequest.swift; sourceTree = "<group>"; };
 		3F5150452C0DD47600AD05C3 /* RegisterUserUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterUserUseCase.swift; sourceTree = "<group>"; };
 		3F5150472C0DD4BB00AD05C3 /* RegisterUserResponseEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterUserResponseEntity.swift; sourceTree = "<group>"; };
@@ -565,6 +571,7 @@
 				00C2F5682C16F82F0009C6A1 /* MemberProfileView.swift */,
 				00C2F5662C15B5560009C6A1 /* SettingView.swift */,
 				00C2F5702C1AFEBC0009C6A1 /* EditProfileView.swift */,
+				3F44C13F2C27E8DC00A5CAFE /* UserInfoView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -874,6 +881,7 @@
 				3F8846012BF254B60021FB79 /* ViewRouter.swift */,
 				3F8846042BF4F13E0021FB79 /* RegisterRouter.swift */,
 				3F8846062BF58B6A0021FB79 /* InvitationRouter.swift */,
+				3F44C13D2C25732E00A5CAFE /* FeedRouter.swift */,
 				000844EE2C1C607600FF33FD /* ProfileRouter.swift */,
 			);
 			path = ViewRouter;
@@ -1123,6 +1131,7 @@
 				9473261A2C1D90850030A182 /* ImageDetailCarouselView.swift */,
 				947326222C23F8350030A182 /* DynamicHeightTextEditorView.swift */,
 				94C7B4422C2407AD00CA378E /* FeedBottomSheetRowView.swift */,
+				3F44C13B2C24394600A5CAFE /* FeedHomeView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -1338,6 +1347,7 @@
 				94103F402C24226800CCF44A /* PostDetailViewModel.swift in Sources */,
 				3FF1070E2BEA097900C52908 /* NotificationAPI.swift in Sources */,
 				9475A6112C1A59DC00333A72 /* PostAlertView.swift in Sources */,
+				3F44C1402C27E8DD00A5CAFE /* UserInfoView.swift in Sources */,
 				3F8B726E2C192BAE00299C24 /* EmojiGridView.swift in Sources */,
 				3FC1FB362BD8C76200AAE53F /* CommentView.swift in Sources */,
 				3F51504C2C0E069900AD05C3 /* RegisterTreeMemberResponseEntity.swift in Sources */,
@@ -1407,6 +1417,7 @@
 				94D1001D2C0CC60A00025D43 /* PhotoPickerManager.swift in Sources */,
 				00C2F5692C16F82F0009C6A1 /* MemberProfileView.swift in Sources */,
 				00F8BB432BC932F000B23AE4 /* UnableRegisterView.swift in Sources */,
+				3F44C13E2C25732E00A5CAFE /* FeedRouter.swift in Sources */,
 				3F1BE13C2C214A9500D3AF1D /* AWSImageRepositoryProtocol.swift in Sources */,
 				3F5150462C0DD47600AD05C3 /* RegisterUserUseCase.swift in Sources */,
 				00B591972C2355D800F7C38C /* CheckAvailableInvitationReponseEntity.swift in Sources */,
@@ -1422,6 +1433,7 @@
 				3F06C3142BFDF34C002B771B /* GetReadCommentResponseDTO.swift in Sources */,
 				3FF107272BEA0ACC00C52908 /* PostReissueTokenResponseDTO.swift in Sources */,
 				0083B4BC2C01D02500F0D252 /* BottomSheet.swift in Sources */,
+				3F44C13C2C24394600A5CAFE /* FeedHomeView.swift in Sources */,
 				3FF107252BEA0AB600C52908 /* PostRegisterUserResponseDTO.swift in Sources */,
 				0087C29A2BE161C9004CED9C /* CheckNameUseCase.swift in Sources */,
 				3FF107082BEA086900C52908 /* GetCheckInvitationsReponseDTO.swift in Sources */,

--- a/Treehouse/Treehouse/Global/Components/TabView/TreeTabView.swift
+++ b/Treehouse/Treehouse/Global/Components/TabView/TreeTabView.swift
@@ -8,47 +8,41 @@
 import SwiftUI
 
 struct TreeTabView: View {
-    
     @Environment(ViewRouter.self) var viewRouter: ViewRouter
     
     var body: some View {
         @Bindable var viewRouter = viewRouter
         
         NavigationStack(path: $viewRouter.path) {
-            ZStack(alignment: .bottom) {
-                TabView {
-                    HomeTab()
-                        .tabItem {
-                            Label("홈", image: "ic_home")
-                        }
-                    
-                    TreeTab()
-                        .tabItem {
-                            Label("트리", image: "ic_tree")
-                        }
-                    
-                    NotificationTab()
-                        .tabItem {
-                            Label("알림", image: "ic_noti")
-                        }
-                    
-                    SettingsTab()
-                        .tabItem {
-                            Label("설정", image: "ic_setting")
-                        }
-                }
-                .font(.fontGuide(.caption2))
-                .tint(.treeGreen)
+            TabView {
+                FeedHomeView()
+                    .tabItem {
+                        Label("홈", image: "ic_home")
+                    }
                 
-                Rectangle()
-                    .frame(maxWidth: .infinity, maxHeight: 1)
-                    .foregroundColor(.gray3)
-                    .padding(.bottom, 52)
+                TreeTab()
+                    .tabItem {
+                        Label("트리", image: "ic_tree")
+                    }
+                
+                NotificationView()
+                    .tabItem {
+                        Label("알림", image: "ic_noti")
+                    }
+                    
+                MyProfileView()
+                    .tabItem {
+                        Label("설정", image: "ic_setting")
+                    }
             }
+            .font(.fontGuide(.caption2))
+            .tint(.treeGreen)
+            .environment(viewRouter)
         }
     }
 }
 
 #Preview {
     TreeTabView()
+        .environment(ViewRouter())
 }

--- a/Treehouse/Treehouse/Presentation/Feed/FeedScene/Views/FeedBottomSheetRowView.swift
+++ b/Treehouse/Treehouse/Presentation/Feed/FeedScene/Views/FeedBottomSheetRowView.swift
@@ -59,7 +59,6 @@ struct FeedBottomSheetRowView: View {
             }
         }
         .padding(.bottom, 33)
-        .frame(width: .infinity)
         .background(.grayscaleWhite)
         .selectCornerRadius(radius: 20, corners: [.topLeft, .topRight])
     }
@@ -78,6 +77,7 @@ struct BottomSheetButton: View {
                     .foregroundColor(textColor)
                 
                 Text(text)
+                    .fontWithLineHeight(fontLevel: .body1)
                     .foregroundColor(textColor)
                 
                 Spacer()

--- a/Treehouse/Treehouse/Presentation/Feed/FeedScene/Views/FeedHomeView.swift
+++ b/Treehouse/Treehouse/Presentation/Feed/FeedScene/Views/FeedHomeView.swift
@@ -1,0 +1,54 @@
+//
+//  FeedHomeView.swift
+//  Treehouse
+//
+//  Created by ParkJunHyuk on 6/20/24.
+//
+
+import SwiftUI
+
+struct FeedHomeView: View {
+    
+    // MARK: - State Property
+    
+    @Environment (ViewRouter.self) var viewRouter
+    
+    @State var isPresent = false
+    @State private var groupName: String = "groupname"
+    @State private var subject: String = "오늘 점심 뭐 먹지?"
+    @State private var personnel: Int = 30
+    
+    // MARK: - View
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            HeaderView(groupName: groupName, isPresent: $isPresent)
+                .frame(height: 56)
+                .frame(maxWidth: .infinity)
+                .background(.grayscaleWhite)
+            
+            ScrollView(.vertical) {
+                TreeHallView(groupName: groupName, subject: subject, personnel: personnel)
+                
+                FeedView()
+                    .frame(width: SizeLiterals.Screen.screenWidth)
+                    .environment(viewRouter)
+            }
+            .padding(.top, 10)
+            .padding(.bottom, 16)
+        }
+        .navigationDestination(for: FeedRouter.self) { router in
+            viewRouter.buildScene(inputRouter: router)
+        }
+        .navigationDestination(for: ProfileRouter.self) { router in
+            viewRouter.buildScene(inputRouter: router)
+        }
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    FeedHomeView()
+        .environment(ViewRouter())
+}

--- a/Treehouse/Treehouse/Presentation/Feed/FeedScene/Views/FeedView.swift
+++ b/Treehouse/Treehouse/Presentation/Feed/FeedScene/Views/FeedView.swift
@@ -27,6 +27,7 @@ struct FeedView: View {
     
     @FocusState private var focusedField: FeedField?
     @FocusState private var isKeyboardShowing: Bool
+    @Environment (ViewRouter.self) var viewRouter
     
     // MARK: - View
     
@@ -35,6 +36,13 @@ struct FeedView: View {
             postTextField
             
             filledFeedView
+                .background(
+                    Color.clear
+                        .contentShape(Rectangle())
+                        .onTapGesture {
+                            viewRouter.push(FeedRouter.postDetailView)
+                        }
+                )
             
             CommentCountView(commentCount: 12)
                 .padding(.leading, 62)
@@ -156,6 +164,7 @@ extension FeedView {
     @ViewBuilder
     var filledFeedView: some View {
         SinglePostView(userProfileImageURL: "", sentTime: 4, postContent: "", postImageURLs: ["", ""])
+            .environment(viewRouter)
     }
 }
 
@@ -163,4 +172,5 @@ extension FeedView {
 
 #Preview {
     FeedView()
+        .environment(ViewRouter())
 }

--- a/Treehouse/Treehouse/Presentation/Feed/FeedScene/Views/PostDetailView.swift
+++ b/Treehouse/Treehouse/Presentation/Feed/FeedScene/Views/PostDetailView.swift
@@ -12,56 +12,58 @@ struct PostDetailView: View {
     
     // MARK: - State Property
     
+    @Environment (ViewRouter.self) var viewRouter
+    @ObservedObject var viewModel: PostDetailViewModel
+    
     @State private var postContent: String = ""
     @State private var textFieldState: TextFieldStateType = .notFocused
     @FocusState private var focusedField: FeedField?
-    @ObservedObject var viewModel: PostDetailViewModel
-
+    
     // MARK: - View
     
     var body: some View {
-        NavigationStack {
-            ZStack {
-                VStack {
-                    ScrollView {
-                        SinglePostView(userProfileImageURL: "", sentTime: 1, postContent: "", postImageURLs: [""])
-                    }
-                    
-                    feedDetailTextField
-                        .onChange(of: focusedField) { _, newValue in
-                            if newValue == .post {
-                                textFieldState = .enable
-                            } else {
-                                textFieldState = .notFocused
-                            }
+        ZStack {
+            VStack {
+                ScrollView {
+                    SinglePostView(userProfileImageURL: "", sentTime: 1, postContent: "", postImageURLs: [""])
+                }
+                
+                feedDetailTextField
+                    .onChange(of: focusedField) { _, newValue in
+                        if newValue == .post {
+                            textFieldState = .enable
+                        } else {
+                            textFieldState = .notFocused
                         }
-                }
-                
-                if viewModel.isDeletePostPopupShowing {
-                    deletePostPopupView
-                }
-            }
-            .onTapGesture {
-                hideKeyboard()
-            }
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .topBarLeading) {
-                    Button(action: {
-                        // TODO: - 뒤로 가기 액션
-                    }) {
-                        Image(systemName: "chevron.left")
-                            .foregroundColor(.treeBlack)
                     }
-                }
-                
-                ToolbarItem(placement: .principal) {
-                    Text("게시글")
-                        .font(.fontGuide(.body2))
-                        .foregroundStyle(.treeBlack)
-                }
+            }
+            
+            if viewModel.isDeletePostPopupShowing {
+                deletePostPopupView
             }
         }
+        .onTapGesture {
+            hideKeyboard()
+        }
+        .navigationBarBackButtonHidden()
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .topBarLeading) {
+                Button(action: {
+                    viewRouter.pop()
+                }) {
+                    Image(systemName: "chevron.left")
+                        .foregroundColor(.treeBlack)
+                }
+            }
+            
+            ToolbarItem(placement: .principal) {
+                Text("게시글")
+                    .font(.fontGuide(.body2))
+                    .foregroundStyle(.treeBlack)
+            }
+        }
+        
     }
 }
 
@@ -146,4 +148,5 @@ extension PostDetailView {
 
 #Preview {
     PostDetailView(viewModel: PostDetailViewModel())
+        .environment(ViewRouter())
 }

--- a/Treehouse/Treehouse/Presentation/Feed/FeedScene/Views/SinglePostView.swift
+++ b/Treehouse/Treehouse/Presentation/Feed/FeedScene/Views/SinglePostView.swift
@@ -12,7 +12,16 @@ struct SelectedImage: Identifiable {
     var id: Int
 }
 
+enum PostType {
+    case feedView
+    case DetailView
+}
+
 struct SinglePostView: View {
+    
+    // MARK: - State Property
+    
+    @Environment (ViewRouter.self) var viewRouter
     
     // MARK: - Property
     
@@ -21,6 +30,7 @@ struct SinglePostView: View {
     let postContent: String
     let postImageURLs: [String]
     let dummyImages = ["img_dummy", "img_dummy_2"]
+    var postType: PostType = .feedView
     
     // MARK:  - State Property
     
@@ -41,6 +51,9 @@ struct SinglePostView: View {
                         .resizable()
                         .clipShape(Circle())
                         .frame(width: 36, height: 36)
+                        .onTapGesture {
+                            viewRouter.push(ProfileRouter.memberProfileView)
+                        }
                     
                     VStack(alignment: .leading) {
                         HStack(alignment: .center, spacing: 9) {
@@ -48,6 +61,9 @@ struct SinglePostView: View {
                                 .font(.fontGuide(.body2))
                                 .foregroundStyle(.treeBlack)
                                 .fontWithLineHeight(fontLevel: .body2)
+                                .onTapGesture {
+                                    viewRouter.push(ProfileRouter.memberProfileView)
+                                }
                             
                             Text("branch 3분 전")
                                 .font(.fontGuide(.caption1))
@@ -131,7 +147,11 @@ extension SinglePostView {
                         .cornerRadius(6.0)
                         .frame(width: 206, height: 172)
                         .onTapGesture {
-                            selectedImage = SelectedImage(id: index)
+                            if postType == .DetailView {
+                                selectedImage = SelectedImage(id: index)
+                            } else {
+                                viewRouter.push(FeedRouter.postDetailView)
+                            }
                         }
                 }
             }
@@ -151,4 +171,5 @@ extension SinglePostView {
                    sentTime: 5,
                    postContent: "",
                    postImageURLs: ["", ""])
+        .environment(ViewRouter())
 }

--- a/Treehouse/Treehouse/Presentation/Notification/NotificationScene/Views/NotificationView.swift
+++ b/Treehouse/Treehouse/Presentation/Notification/NotificationScene/Views/NotificationView.swift
@@ -10,37 +10,27 @@ import SwiftUI
 struct NotificationView: View {
     
     // MARK: - Property
-    
+    @Environment(ViewRouter.self) var viewRouter: ViewRouter
     let notifications = NotificationModel.notificationDummyData
     
     // MARK: - View
     
     var body: some View {
-        NavigationStack {
-            Group {
-                if !notifications.isEmpty {
-                    ScrollView {
-                        VStack(alignment: .leading, spacing: 0) {
-                            ForEach(notifications) { notification in
-                                NotificationRow(notification: notification)
-                            }
+        Group {
+            if !notifications.isEmpty {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 0) {
+                        ForEach(notifications) { notification in
+                            NotificationRow(notification: notification)
                         }
                     }
-                    
-                } else {
-                    emptyNotificationView
                 }
-            }
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .navigationBarLeading) {
-                    Text("알림")
-                        .font(.fontGuide(.heading3))
-                        .padding(.leading, 14)
-                        .padding(.bottom, 13)
-                }
+                
+            } else {
+                emptyNotificationView
             }
         }
+        .navigationBarTitleDisplayMode(.inline)
     }
 }
 
@@ -63,4 +53,5 @@ extension NotificationView {
 
 #Preview {
     NotificationView()
+        .environment(ViewRouter())
 }

--- a/Treehouse/Treehouse/Presentation/Profile/Views/EditProfileView.swift
+++ b/Treehouse/Treehouse/Presentation/Profile/Views/EditProfileView.swift
@@ -11,6 +11,8 @@ struct EditProfileView: View {
     
     // MARK: - State Property
     
+    @Environment(ViewRouter.self) var viewRouter: ViewRouter
+    
     @State private var profileImage: Image? = Image(.imgUser)
     @State private var name: String = "username"
     @State private var bio: String = "바이오입니다."
@@ -134,11 +136,26 @@ struct EditProfileView: View {
             }
             .padding(.bottom, SizeLiterals.Screen.screenHeight * 64 / 852)
         }
+        .navigationBarBackButtonHidden()
+        .toolbar {
+            ToolbarItem(placement: .topBarLeading) {
+                Button(action: {
+                    viewRouter.pop()
+                }) {
+                    Image(systemName: "chevron.left")
+                        .foregroundColor(.treeBlack)
+                }
+                .padding(.top, 5)
+            }
+        }
     }
 }
 
 // MARK: - Preview
 
 #Preview {
-    EditProfileView()
+    NavigationStack {
+        EditProfileView()
+            .environment(ViewRouter())
+    }
 }

--- a/Treehouse/Treehouse/Presentation/Profile/Views/MemberProfileView.swift
+++ b/Treehouse/Treehouse/Presentation/Profile/Views/MemberProfileView.swift
@@ -15,6 +15,7 @@ struct MemberProfileView: View {
     let availableInvitaion = AvailableInvitationStruct.availableInvitationDummyData
     
     // MARK: - State Property
+    @Environment(ViewRouter.self) var viewRouter: ViewRouter
     
     @State var isPresent = false
     @State private var userName: String = "username"
@@ -28,239 +29,38 @@ struct MemberProfileView: View {
     // MARK: - View
     
     var body: some View {
-        ZStack {
-            ScrollView() {
-                VStack(spacing: 0) {
-                    HStack(alignment: .top, spacing: 0) {
-                        Image(.imgUser)
-                            .resizable()
-                            .frame(width: 80, height: 80)
-                            .padding(.leading, SizeLiterals.Screen.screenWidth * 16 / 393)
-                        
-                        VStack(alignment: .leading, spacing: 5) {
-                            HStack(spacing: 6) {
-                                Text(userName)
-                                    .fontWithLineHeight(fontLevel: .heading4)
-                                    .foregroundColor(.grayscaleBlack)
-                                
-                                Text("@\(userId)")
-                                    .fontWithLineHeight(fontLevel: .body3)
-                                    .foregroundColor(.gray6)
-                            }
-                            
-                            VStack {
-                                HStack {
-                                    Text(bio)
-                                        .fontWithLineHeight(fontLevel: .body5)
-                                        .foregroundColor(.grayscaleBlack)
-                                        .padding(12)
-                                    Spacer()
-                                }
-                            }
-                            .background(
-                                Rectangle()
-                                    .selectCornerRadius(radius: 10, corners: .topRight)
-                                    .selectCornerRadius(radius: 10, corners: .bottomLeft)
-                                    .selectCornerRadius(radius: 10, corners: .bottomRight)
-                                    .foregroundColor(.gray2)
-                            )
-                        }
-                        .padding(.leading, SizeLiterals.Screen.screenWidth * 12 / 393)
-                        .padding(.trailing, SizeLiterals.Screen.screenWidth * 12 / 393)
-                        .offset(y: -3)
-                        
-                        Spacer()
-                    }
-                    
-                    HStack(spacing: 0) {
-                        VStack(spacing: 6) {
-                            Text("\(branchCount)명")
-                                .fontWithLineHeight(fontLevel: .heading3)
-                                .foregroundColor(.treeBlack)
-                            
-                            Text(StringLiterals.Profile.profileBranchCountTitle)
-                                .fontWithLineHeight(fontLevel: .caption1)
-                                .foregroundColor(.gray6)
-                        }
-                        .padding(.leading, SizeLiterals.Screen.screenWidth * 45 / 393)
-                        
-                        Spacer()
-                        
-                        VStack(spacing: 6) {
-                            Text("\(treeHouseCount)개")
-                                .fontWithLineHeight(fontLevel: .heading3)
-                                .foregroundColor(.treeBlack)
-                            
-                            Text(StringLiterals.Profile.profileTreeHouseCountTitle)
-                                .fontWithLineHeight(fontLevel: .caption1)
-                                .foregroundColor(.gray6)
-                        }
-                        
-                        Spacer()
-                        
-                        VStack(spacing: 6) {
-                            Text(root)
-                                .fontWithLineHeight(fontLevel: .heading3)
-                                .foregroundColor(.treeBlack)
-                            
-                            Text(StringLiterals.Profile.profileRootTitle)
-                                .fontWithLineHeight(fontLevel: .caption1)
-                                .foregroundColor(.gray6)
-                        }
-                        .padding(.trailing, SizeLiterals.Screen.screenWidth * 45 / 393)
-                    }
-                    .padding(.top, 10)
-                    
-                    HStack(spacing: SizeLiterals.Screen.screenWidth * 17 / 393) {
-                        Button(action: {}) {
-                            Text(StringLiterals.Profile.buttonLabel2)
-                                .font(.fontGuide(.body2))
-                                .foregroundStyle(.gray1)
-                                .frame(width: SizeLiterals.Screen.screenWidth * 172 / 393, height: 48)
-                                .background(.treeGreen)
-                                .cornerRadius(12)
-                        }
-                        .padding(.top, 26)
-                        
-                        Button(action: {
-                            isPresent = true
-                        }) {
-                            Text(StringLiterals.Profile.buttonLabel3)
-                                .font(.fontGuide(.body2))
-                                .foregroundStyle(.gray1)
-                                .frame(width: SizeLiterals.Screen.screenWidth * 172 / 393, height: 48)
-                                .background(.treeBlack)
-                                .cornerRadius(12)
-                        }
-                        .padding(.top, 26)
-                    }
-                    
-                    Rectangle()
-                        .frame(height: 10)
-                        .foregroundColor(.gray2)
-                        .padding(.top, 20)
-                }
+        ScrollView(.vertical) {
+            VStack(spacing: 0) {
+                UserInfoView(infoType: .memberProfile,
+                             userName: "memberName",
+                             userId: "memberid",
+                             bio: "멤버 바이오입니다.",
+                             branchCount: 0,
+                             treeHouseCount: 0,
+                             root: "Root",
+                             inviteAction: nil,
+                             branchAction: nil,
+                             profileAction: nil)
             }
-            
-            ZStack(alignment: .bottom) {
-                Color.black.opacity(0.5)
-                    .edgesIgnoringSafeArea(.top)
-                    .opacity(isPresent ? 1 : 0)
-                    .onTapGesture {
-                        isPresent = false
-                        selectedGroupId = nil
-                    }
-                
-                if self.isPresent {
-                    BottomSheet($isPresent, height: SizeLiterals.Screen.screenHeight * 730 / 852) {
-                        VStack(spacing: 0) {
-                            HStack(spacing: 0) {
-                                Image(.imgUser)
-                                    .resizable()
-                                    .frame(width: 36, height: 36)
-                                    .padding(.leading, SizeLiterals.Screen.screenWidth * 16 / 393)
-                                
-                                Text(userName)
-                                    .fontWithLineHeight(fontLevel: .body2)
-                                    .padding(.leading, 10)
-                                
-                                Text(StringLiterals.MemberProfile.bottomSheetLabel1)
-                                    .fontWithLineHeight(fontLevel: .body3)
-                                    .padding(.leading, 6)
-                                
-                                Spacer()
-                            }
-                            .padding(.top, 13)
-                            
-                            HStack {
-                                Text("가진 초대장 : \(availableInvitaion.availableInvitation)개")
-                                    .fontWithLineHeight(fontLevel: .heading4)
-                                    .padding(.leading, SizeLiterals.Screen.screenWidth * 16 / 393)
-                                
-                                Spacer()
-                            }
-                            .padding(.top, 24)
-                            
-                            Text(StringLiterals.Invitation.guidanceTitle1)
-                                .fontWithLineHeight(fontLevel: .body3)
-                                .foregroundStyle(.gray6)
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                                .padding(.top, 5)
-                                .padding(.horizontal, SizeLiterals.Screen.screenWidth * 16 / 393)
-                            
-                            HStack(spacing: 27) {
-                                ZStack(alignment: .leading) {
-                                    RoundedRectangle(cornerRadius: 16)
-                                        .fill(.gray2)
-                                        .frame(width: SizeLiterals.Screen.screenWidth * 292/393)
-                                        .frame(height: 10)
-                                        .padding(.top, 16)
-                                    
-                                    RoundedRectangle(cornerRadius: 16)
-                                        .fill(.treeBlack)
-                                        .frame(width: CGFloat(availableInvitaion.activeRate)/100 * SizeLiterals.Screen.screenWidth * 292/393)
-                                        .frame(height: 10)
-                                        .padding(.top, 16)
-                                }
-                                
-                                Image("ic_invitation")
-                                    .offset(y: 7)
-                            }
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .frame(height: 42)
-                            .padding(.horizontal, SizeLiterals.Screen.screenWidth * 16 / 393)
-                            
-                            HStack {
-                                Text(StringLiterals.MemberProfile.bottomSheetLabel2)
-                                    .fontWithLineHeight(fontLevel: .heading4)
-                                    .foregroundColor(.grayscaleBlack)
-                                    .padding(.leading, SizeLiterals.Screen.screenWidth * 16 / 393)
-                                
-                                Spacer()
-                            }
-                            .padding(.top, 24)
-                            
-                            if groupList.count > (SizeLiterals.Screen.screenHeight/2 > 400 ? 3 : 2) {
-                                ScrollView {
-                                    ForEach(groupList) { group in
-                                        MemberGroupRow(group: group, isSelected: group.id == selectedGroupId) {
-                                            selectedGroupId = group.id
-                                        }
-                                    }
-                                }
-                                .scrollIndicators(.never)
-                                .frame(height: SizeLiterals.Screen.screenHeight/2 > 400 ? 260 : 170)
-                                .padding(.top, 14)
-                            } else {
-                                ForEach(groupList) { group in
-                                    MemberGroupRow(group: group, isSelected: group.id == selectedGroupId) {
-                                        selectedGroupId = group.id
-                                    }
-                                }
-                                .padding(.top, 14)
-                            }
-                            
-                            Spacer()
-                            
-                            Button(action: {
-                                isPresent = false
-                                selectedGroupId = nil
-                            }) {
-                                Text("초대하기")
-                                    .font(.fontGuide(.body2))
-                                    .foregroundStyle((selectedGroupId != nil) ? .gray1 : .gray6)
-                                    .frame(width: SizeLiterals.Screen.screenWidth * 360 / 393, height: 56)
-                                    .background((selectedGroupId != nil) ? .treeBlack : .gray2)
-                                    .cornerRadius(12)
-                            }
-                            .padding(.bottom, SizeLiterals.Screen.screenHeight * 64 / 852)
-                        }
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .padding(.top, 15)
+        .navigationBarBackButtonHidden()
+        .toolbar {
+            ToolbarItem(placement: .topBarLeading) {
+                Button(action: {
+                    viewRouter.pop()
+                }) {
+                    HStack {
+                        Image(systemName: "chevron.left")
+                            .foregroundColor(.grayscaleBlack)
+                        
+                        Text(userName)
+                            .fontWithLineHeight(fontLevel: .heading4)
+                            .foregroundStyle(.grayscaleBlack)
                     }
                 }
+                .padding(.top, 5)
             }
-            .edgesIgnoringSafeArea(.all)
-            .animation(.interactiveSpring(), value: isPresent)
         }
     }
 }
@@ -268,6 +68,9 @@ struct MemberProfileView: View {
 // MARK: - Preview
 
 #Preview {
-    MemberProfileView()
+    NavigationStack {
+        MemberProfileView()
+            .environment(ViewRouter())
+    }
 }
 

--- a/Treehouse/Treehouse/Presentation/Profile/Views/MyProfileView.swift
+++ b/Treehouse/Treehouse/Presentation/Profile/Views/MyProfileView.swift
@@ -6,12 +6,13 @@
 //
 
 import SwiftUI
+import PopupView
 
 struct MyProfileView: View {
     
     // MARK: - State Property
     
-    @Environment(ViewRouter.self) private var viewRouter
+    @Environment(ViewRouter.self) var viewRouter: ViewRouter
     
     @State private var userName: String = "username"
     @State private var userId: String = "userid"
@@ -19,115 +20,55 @@ struct MyProfileView: View {
     @State private var branchCount: Int = 0
     @State private var treeHouseCount: Int = 0
     @State private var root: String = "Root"
+    @State var isPresent = false
+    @State private var groupName: String = "groupname"
     
     // MARK: - View
     
     var body: some View {
-        ScrollView() {
-            VStack(spacing: 0) {
-                HStack(alignment: .top, spacing: 0) {
-                    Image(.imgUser)
-                        .frame(width: 80, height: 80)
-                        .padding(.leading, SizeLiterals.Screen.screenWidth * 16 / 393)
+        VStack(spacing: 0) {
+            HeaderView(groupName: groupName, isPresent: $isPresent)
+                .frame(height: 56)
+                .frame(maxWidth: .infinity)
+                .background(.grayscaleWhite)
+            
+            ScrollView(.vertical) {
+                VStack(spacing: 0) {
+                    UserInfoView(infoType: .myProfile,
+                                 userName: "userName",
+                                 userId: "userid",
+                                 bio: "바이오입니다.",
+                                 branchCount: 0,
+                                 treeHouseCount: 0,
+                                 root: "Root",
+                                 inviteAction: nil,
+                                 branchAction: nil,
+                                 profileAction: { viewRouter.push(ProfileRouter.editProfileView) })
                     
-                    VStack(alignment: .leading, spacing: 5) {
-                        HStack(spacing: 6) {
-                            Text(userName)
-                                .fontWithLineHeight(fontLevel: .heading4)
-                                .foregroundColor(.grayscaleBlack)
-                            
-                            Text("@\(userId)")
-                                .fontWithLineHeight(fontLevel: .body3)
-                                .foregroundColor(.gray6)
-                        }
-                        
-                        VStack {
-                            HStack {
-                                Text(bio)
-                                    .fontWithLineHeight(fontLevel: .body5)
-                                    .foregroundColor(.grayscaleBlack)
-                                    .padding(12)
-                                    .frame(width: SizeLiterals.Screen.screenWidth * 268 / 393, alignment: .leading)
-                            }
-                        }
-                        .background(
-                            Rectangle()
-                                .selectCornerRadius(radius: 10, corners: .topRight)
-                                .selectCornerRadius(radius: 10, corners: .bottomLeft)
-                                .selectCornerRadius(radius: 10, corners: .bottomRight)
-                                .foregroundColor(.gray2)
-                        )
-                    }
-                    .padding(.leading, SizeLiterals.Screen.screenWidth * 12 / 393)
-                    .padding(.trailing, SizeLiterals.Screen.screenWidth * 12 / 393)
-                    .offset(y: -3)
+                    SettingView(state: .accountSetting)
                     
-                    Spacer()
+                    SettingView(state: .systemSetting)
+                    
+                    SettingView(state: .aboutTreeHouse)
+                    
+                    SettingView(state: .serviceSetting)
                 }
-                
-                HStack(spacing: 0) {
-                    VStack(spacing: 6) {
-                        Text("\(branchCount)명")
-                            .fontWithLineHeight(fontLevel: .heading3)
-                            .foregroundColor(.treeBlack)
-                        
-                        Text(StringLiterals.Profile.profileBranchCountTitle)
-                            .fontWithLineHeight(fontLevel: .caption1)
-                            .foregroundColor(.gray6)
-                    }
-                    .padding(.leading, SizeLiterals.Screen.screenWidth * 45 / 393)
-                    
-                    Spacer()
-                    
-                    VStack(spacing: 6) {
-                        Text("\(treeHouseCount)개")
-                            .fontWithLineHeight(fontLevel: .heading3)
-                            .foregroundColor(.treeBlack)
-                        
-                        Text(StringLiterals.Profile.profileTreeHouseCountTitle)
-                            .fontWithLineHeight(fontLevel: .caption1)
-                            .foregroundColor(.gray6)
-                    }
-                    
-                    Spacer()
-                    
-                    VStack(spacing: 6) {
-                        Text(root)
-                            .fontWithLineHeight(fontLevel: .heading3)
-                            .foregroundColor(.treeBlack)
-                        
-                        Text(StringLiterals.Profile.profileRootTitle)
-                            .fontWithLineHeight(fontLevel: .caption1)
-                            .foregroundColor(.gray6)
-                    }
-                    .padding(.trailing, SizeLiterals.Screen.screenWidth * 45 / 393)
-                }
-                .padding(.top, 10)
-                
-                Button(action: {
-                    viewRouter.push(ProfileRouter.editProfileView)
-                }) {
-                    Text(StringLiterals.Profile.buttonLabel1)
-                        .font(.fontGuide(.body2))
-                        .foregroundStyle(.gray1)
-                        .frame(width: SizeLiterals.Screen.screenWidth * 360 / 393, height: 48)
-                        .background(.treeBlack)
-                        .cornerRadius(12)
-                }
-                .padding(.top, 26)
-                
-                Rectangle()
-                    .frame(height: 10)
-                    .foregroundColor(.gray2)
-                    .padding(.top, 20)
-                
-                SettingView(state: .accountSetting)
-                
-                SettingView(state: .systemSetting)
-                
-                SettingView(state: .aboutTreeHouse)
-                
-                SettingView(state: .serviceSetting)
+            }
+            .padding(.top, 10)
+            .padding(.bottom, 16)
+            .navigationDestination(for: ProfileRouter.self) { router in
+                viewRouter.buildScene(inputRouter: router)
+            }
+            // 바텀시트 표출
+            .popup(isPresented: $isPresent) {
+                Text("asdfasdf")
+            } customize: {
+                $0
+                    .type(.toast)
+                    .closeOnTapOutside(true)
+                    .dragToDismiss(true)
+                    .isOpaque(true)
+                    .backgroundColor(.treeBlack.opacity(0.5))
             }
         }
     }
@@ -136,6 +77,8 @@ struct MyProfileView: View {
 // MARK: - Preview
 
 #Preview {
-    MyProfileView()
-        .environment(ViewRouter())
+    NavigationStack {
+        MyProfileView()
+            .environment(ViewRouter())
+    }
 }

--- a/Treehouse/Treehouse/Presentation/Profile/Views/UserInfoView.swift
+++ b/Treehouse/Treehouse/Presentation/Profile/Views/UserInfoView.swift
@@ -1,0 +1,188 @@
+//
+//  UserInfoView.swift
+//  Treehouse
+//
+//  Created by ParkJunHyuk on 6/23/24.
+//
+
+import SwiftUI
+
+enum userInfoType {
+    case myProfile
+    case memberProfile
+}
+
+struct UserInfoView: View {
+    
+    // MARK: - Property
+    
+    var infoType: userInfoType
+    var userName: String
+    var userId: String
+    var bio: String
+    var branchCount: Int
+    var treeHouseCount: Int
+    var root: String
+    
+    // MARK: - Closure Property
+    
+    let inviteAction: (() -> Void)?
+    let branchAction: (() -> Void)?
+    let profileAction: (() -> Void)?
+    
+    // MARK: - View
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack(alignment: .top, spacing: 0) {
+                Image(.imgUser)
+                    .frame(width: 80, height: 80)
+                    .padding(.leading, SizeLiterals.Screen.screenWidth * 16 / 393)
+                
+                VStack(alignment: .leading, spacing: 5) {
+                    HStack(spacing: 6) {
+                        Text(userName)
+                            .fontWithLineHeight(fontLevel: .heading4)
+                            .foregroundColor(.grayscaleBlack)
+                        
+                        Text("@\(userId)")
+                            .fontWithLineHeight(fontLevel: .body3)
+                            .foregroundColor(.gray6)
+                    }
+                    
+                    VStack {
+                        Text(bio)
+                            .fontWithLineHeight(fontLevel: .body5)
+                            .foregroundColor(.grayscaleBlack)
+                            .padding(12)
+                            .frame(width: SizeLiterals.Screen.screenWidth * 268 / 393, alignment: .leading)
+                    }
+                    .background(
+                        Rectangle()
+                            .selectCornerRadius(radius: 10, corners: [.topRight, .bottomLeft, .bottomRight])
+                            .foregroundColor(.gray2)
+                    )
+                }
+                .padding(.leading, SizeLiterals.Screen.screenWidth * 12 / 393)
+                .padding(.trailing, SizeLiterals.Screen.screenWidth * 12 / 393)
+            }
+            
+            treehouseInfoView
+                .padding(.top, 25)
+            
+            infoMenuButtons
+                .padding(.top, 14)
+                .padding(.horizontal, 16)
+            
+            Rectangle()
+                .frame(height: 12)
+                .foregroundColor(.gray2)
+                .padding(.top, 20)
+        }
+    }
+}
+
+// MARK: - ViewBuilder
+
+private extension UserInfoView {
+    @ViewBuilder
+    var treehouseInfoView: some View {
+        HStack(spacing: 0) {
+            VStack(spacing: 6) {
+                Text("\(branchCount)명")
+                    .fontWithLineHeight(fontLevel: .heading3)
+                    .foregroundColor(.treeBlack)
+                
+                Text(StringLiterals.Profile.profileBranchCountTitle)
+                    .fontWithLineHeight(fontLevel: .caption1)
+                    .foregroundColor(.gray6)
+            }
+            
+            Spacer()
+            
+            VStack(spacing: 6) {
+                Text("\(treeHouseCount)개")
+                    .fontWithLineHeight(fontLevel: .heading3)
+                    .foregroundColor(.treeBlack)
+                
+                Text(StringLiterals.Profile.profileTreeHouseCountTitle)
+                    .fontWithLineHeight(fontLevel: .caption1)
+                    .foregroundColor(.gray6)
+            }
+            
+            Spacer()
+            
+            VStack(spacing: 6) {
+                Text(root)
+                    .fontWithLineHeight(fontLevel: .heading3)
+                    .foregroundColor(.treeBlack)
+                
+                Text(StringLiterals.Profile.profileRootTitle)
+                    .fontWithLineHeight(fontLevel: .caption1)
+                    .foregroundColor(.gray6)
+            }
+        }
+        .padding(.leading, SizeLiterals.Screen.screenWidth * 39 / 393)
+        .padding(.trailing, SizeLiterals.Screen.screenWidth * 44 / 393)
+        .padding(.vertical, 12)
+    }
+    
+    @ViewBuilder
+    var infoMenuButtons: some View {
+        switch infoType {
+        case .memberProfile:
+            HStack(spacing: 17) {
+                Button(action: {
+                    branchAction?()
+                }) {
+                    Text(StringLiterals.Profile.buttonLabel2)
+                        .font(.fontGuide(.body4))
+                        .foregroundStyle(.gray1)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 14)
+                        .background(.treeGreen)
+                        .cornerRadius(12)
+                }
+                
+                Button(action: {
+                    inviteAction?()
+                }) {
+                    Text(StringLiterals.Profile.buttonLabel3)
+                        .font(.fontGuide(.body4))
+                        .foregroundStyle(.gray1)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 14)
+                        .background(.treeBlack)
+                        .cornerRadius(12)
+                }
+            }
+        case .myProfile:
+            Button(action: {
+                profileAction?()
+            }) {
+                Text(StringLiterals.Profile.buttonLabel1)
+                    .font(.fontGuide(.body4))
+                    .foregroundStyle(.gray1)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 14)
+                    .background(.treeBlack)
+                    .cornerRadius(12)
+            }
+        }
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    UserInfoView(infoType: .memberProfile,
+                 userName: "username", 
+                 userId: "userId",
+                 bio: "userBio",
+                 branchCount: 0,
+                 treeHouseCount: 0,
+                 root: "Root",
+                 inviteAction: nil,
+                 branchAction: nil,
+                 profileAction: nil)
+}

--- a/Treehouse/Treehouse/ViewRouter/FeedRouter.swift
+++ b/Treehouse/Treehouse/ViewRouter/FeedRouter.swift
@@ -1,0 +1,21 @@
+//
+//  FeedRouter.swift
+//  Treehouse
+//
+//  Created by ParkJunHyuk on 6/21/24.
+//
+
+import SwiftUI
+
+enum FeedRouter: Router {
+    typealias ContentView = AnyView
+    
+    case postDetailView
+    
+    func buildView(_ viewModel: BaseViewModel?) -> ContentView {
+        switch self {
+        case .postDetailView:
+            return AnyView(PostDetailView(viewModel: PostDetailViewModel()))
+        }
+    }
+}

--- a/Treehouse/Treehouse/ViewRouter/ProfileRouter.swift
+++ b/Treehouse/Treehouse/ViewRouter/ProfileRouter.swift
@@ -12,11 +12,14 @@ enum ProfileRouter: Router {
     typealias ContentView = AnyView
     
     case editProfileView
+    case memberProfileView
     
     func buildView(_ viewModel: BaseViewModel?) -> ContentView {
         switch self {
         case .editProfileView:
             return AnyView(EditProfileView())
+        case .memberProfileView:
+            return AnyView(MemberProfileView())
         }
     }
 }

--- a/Treehouse/Treehouse/ViewRouter/ViewRouter.swift
+++ b/Treehouse/Treehouse/ViewRouter/ViewRouter.swift
@@ -28,7 +28,7 @@ enum ViewType {
 @Observable
 final class ViewRouter: RouterAction {
     
-    private(set) var currentView: ViewType = .userAuthentication
+    private(set) var currentView: ViewType = .enterTreehouse
     
     var path = NavigationPath() {
         didSet {
@@ -67,5 +67,10 @@ final class ViewRouter: RouterAction {
     @ViewBuilder
     func buildScene<RouterType: Router, ViewModelType: BaseViewModel>(inputRouter: RouterType, viewModel: ViewModelType?) -> some View {
         inputRouter.buildView(viewModel)
+    }
+    
+    @ViewBuilder
+    func buildScene<RouterType: Router>(inputRouter: RouterType) -> some View {
+        inputRouter.buildView(nil)
     }
 }


### PR DESCRIPTION
## 📟 관련 이슈
- Resolved: #71 

## 👷 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
- MyProfileView 와 MemberProfileView 의 공통부분을 UserInfoView 로 구현
- ViewModel 이 필요하지 않은 ViewRouter 의 builder 메서드 구현
- Feed, Profile Router 구현
- 색상, 화면 전환을 위한 코드 작성 및 수정

## 🚨 참고 사항
<!-- 참고 사항을 적어주세요. 없으면 지워주세요. -->
### `ViewRouter` 의 buildScene 메서드 추가
``` swift
final class ViewRouter: RouterAction {
    @ViewBuilder
    func buildScene<RouterType: Router>(inputRouter: RouterType) -> some View {
        inputRouter.buildView(nil)
    }
}

// 사용법
viewRouter.buildScene(inputRouter: router)
```
기존에 있었던 buildScene 메서드는 ViewModel 을 항상 넣어야만 했습니다.
현재 ViewModel 이 필요없는 View 가 존재하여 다음과 같이 새로운 메서드를 추가하였습니다.

### `FeedView` 의 onTapGesture
``` swift
struct FeedView: View {
    filledFeedView
        .background(
            Color.clear
                .contentShape(Rectangle())
                .onTapGesture {
                    viewRouter.push(FeedRouter.postDetailView)
                }
        )
}
```
게시글에는 다양한 TapGesture 가 존재하는데 각자의 action 을 허용하면서 다른 부분을 눌렀을 때는 DetailView 로 넘어가야합니다. 
다음과 같이 전체 게시글을 의미하는 filledFeedView 의 전체 배경을 설정하고자 Color.clear 를 선언해주었고 다음과 같이 넘어갈 수 있도록 구현했습니다.

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "https://github.com/Team-Shaka/Tree-House-iOS/assets/45564605/db417b3a-c3cd-4888-916f-2a2eda1e42f3" width ="250">|

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
