### PR TITLE
[Fix] #85 - Image 크기 줄이는 로직 추가 및 회원 가입 시 필요한 이미지 관련 코드 수정

### DIFF
--- a/Treehouse/Treehouse/Domain/Entities/Register/ExistsUserLoginResponseEntity.swift
+++ b/Treehouse/Treehouse/Domain/Entities/Register/ExistsUserLoginResponseEntity.swift
@@ -9,7 +9,7 @@ import Foundation
 
 struct ExistsUserLoginResponseEntity: Decodable {
     let userId: Int
-    let refreshToken: String
     let accessToken: String
+    let refreshToken: String
     let treehouseIdList: [Int]
 }

--- a/Treehouse/Treehouse/Global/Extension/Image+.swift
+++ b/Treehouse/Treehouse/Global/Extension/Image+.swift
@@ -38,4 +38,12 @@ extension Image {
             self = Image(defaultImage)
         }
     }
+    
+    init(uiImage: UIImage?, defaultImage: ImageResource) {
+        if let uiImage = uiImage {
+            self = Image(uiImage: uiImage)
+        } else {
+            self = Image(defaultImage)
+        }
+    }
 }

--- a/Treehouse/Treehouse/Global/PhotoPicker/PhotoPickerManager.swift
+++ b/Treehouse/Treehouse/Global/PhotoPicker/PhotoPickerManager.swift
@@ -102,8 +102,6 @@ struct PhotoPicker: UIViewControllerRepresentable {
                     print(image.pngData()!)
                     resizeImages[index] = image
                 }
-                
-                await group.waitForAll()
             }
             
             return resizeImages

--- a/Treehouse/Treehouse/Global/PhotoPicker/PhotoPickerManager.swift
+++ b/Treehouse/Treehouse/Global/PhotoPicker/PhotoPickerManager.swift
@@ -80,10 +80,33 @@ struct PhotoPicker: UIViewControllerRepresentable {
             guard let imageData = image.pngData() else { return image }
             
             if let downsampledImage = UIImage.downsample(imageData: imageData, to: self.type.imageSize, scale: UIScreen.main.scale) {
+                print("이미지 줄이기 성공")
                 return downsampledImage
             } else {
                 return image
             }
+        }
+        
+        func resizeImageInParallel(images: [UIImage]) async -> [UIImage] {
+            var resizeImages = images
+            
+            await withTaskGroup(of: (Int, UIImage).self) { group in
+                for (index, image) in images.enumerated() {
+                    group.addTask {
+                        let result = await self.resizeImage(image: image)
+                        return (index, result)
+                    }
+                }
+                
+                for await (index, image) in group {
+                    print(image.pngData()!)
+                    resizeImages[index] = image
+                }
+                
+                await group.waitForAll()
+            }
+            
+            return resizeImages
         }
         
         func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
@@ -107,7 +130,10 @@ struct PhotoPicker: UIViewControllerRepresentable {
             }
             
             group.notify(queue: DispatchQueue.main) {
-                self.parent.selectedImages = images
+                Task {
+                    let resizedImages = await self.resizeImageInParallel(images: images)
+                    self.parent.selectedImages = resizedImages
+                }
             }
         }
     }

--- a/Treehouse/Treehouse/Global/SwiftData/UserInfoViewModel.swift
+++ b/Treehouse/Treehouse/Global/SwiftData/UserInfoViewModel.swift
@@ -33,6 +33,7 @@ final class UserInfoViewModel: BaseViewModel {
     
     /// UserInfoData 를 처음으로 만들기 위한 메서드
     func createData(newData: UserInfoData) -> Bool {
+        print("User Data 저장")
         userInfo = newData
         return insertData(data: safeUserInfo)
     }

--- a/Treehouse/Treehouse/Network/Register/DTO/Response/PostExistsUserLoginResponseDTO.swift
+++ b/Treehouse/Treehouse/Network/Register/DTO/Response/PostExistsUserLoginResponseDTO.swift
@@ -9,11 +9,11 @@ import Foundation
 
 struct PostExistsUserLoginResponseDTO: Decodable {
     let userId: Int
-    let refreshToken: String
     let accessToken: String
+    let refreshToken: String
     let treehouseIdList: [Int]
 
     func toDomain() -> ExistsUserLoginResponseEntity {
-        return ExistsUserLoginResponseEntity(userId: userId, refreshToken: refreshToken, accessToken: accessToken, treehouseIdList: treehouseIdList)
+        return ExistsUserLoginResponseEntity(userId: userId, accessToken: accessToken, refreshToken: refreshToken, treehouseIdList: treehouseIdList)
     }
 }

--- a/Treehouse/Treehouse/Presentation/Auth/RegisterScene/ViewModels/UserPhoneViewModel.swift
+++ b/Treehouse/Treehouse/Presentation/Auth/RegisterScene/ViewModels/UserPhoneViewModel.swift
@@ -35,7 +35,7 @@ final class CheckUserPhoneViewModel: BaseViewModel {
 extension CheckUserPhoneViewModel {
     func checkUserPhone(phoneNumber: String) async {
         
-        let result = await checkUserPhoneUseCase.execute(phoneNumber: phoneNumber)
+        let result = await checkUserPhoneUseCase.execute(phoneNumber: phoneNumber.formatPhoneNumber)
         
         switch result {
         case .success(let response):

--- a/Treehouse/Treehouse/Presentation/Auth/RegisterScene/ViewModels/UserSettingViewModel.swift
+++ b/Treehouse/Treehouse/Presentation/Auth/RegisterScene/ViewModels/UserSettingViewModel.swift
@@ -47,7 +47,7 @@ final class UserSettingViewModel: BaseViewModel {
     var memberNum: Int = 0
     var memberProfileImages: [String?] = []
     
-    var profileImage: [UIImage]?
+    var profileImage: UIImage?
     
     // MARK: - State Property
     
@@ -119,7 +119,7 @@ final class UserSettingViewModel: BaseViewModel {
             return nil
         }
         
-        if let profileImageData = profileImage?.first?.pngData() {
+        if let profileImageData = profileImage?.pngData() {
             return UserInfoData(userId: userId, userName: userName, treeMemberName: memberName, treehouseId: [treehouseId: treehouseName], bio: bio, profileImageData: profileImageData)
         } else {
             guard let imageData = UIImage(resource: .imgUser).pngData() else {
@@ -207,11 +207,12 @@ extension UserSettingViewModel {
     func registerTreeMember() async -> Bool {
         guard let treehouseId = treehouseId,
               let memberName = memberName,
-              let bio = bio else {
+              let bio = bio,
+              let accessUrlImage = accessUrlImage.first else {
             return false
         }
         
-        let result = await registerTreeMemberUseCase.execute(requestDTO: PostRegisterTreeMemberRequestDTO(treehouseId: treehouseId, userName: userName, memberName: memberName, bio: bio, profileImageURL: accessUrlImage[0]))
+        let result = await registerTreeMemberUseCase.execute(requestDTO: PostRegisterTreeMemberRequestDTO(treehouseId: treehouseId, userName: userName, memberName: memberName, bio: bio, profileImageURL: accessUrlImage))
         
         switch result {
         case .success(let response):
@@ -263,7 +264,6 @@ extension UserSettingViewModel {
                 memberProfileImages = $0.treehouseMemberProfileImages
             }
             
-//            await loadImagesAWS(images: memberProfileImages)
         case .failure(let error):
             await MainActor.run {
                 self.errorMessage = error.localizedDescription
@@ -276,7 +276,8 @@ extension UserSettingViewModel {
 extension UserSettingViewModel {
     func presignedURL() async -> Bool {
         
-        guard let treehouseId = treehouseId, let imageDataSize = profileImage?.first?.getImageBitSize()else {
+        guard let treehouseId = treehouseId, 
+                let imageDataSize = profileImage?.getImageBitSize() else {
             print("treehouseId")
             return false
         }
@@ -304,15 +305,16 @@ extension UserSettingViewModel {
         
         guard let uploadImages = profileImage else { return }
         
-        let result = await uploadImageToAWSUseCase.execute(presignedUrls: presignedUrlImage, uploadImages: uploadImages)
+        let result = await uploadImageToAWSUseCase.execute(presignedUrls: presignedUrlImage, uploadImages: [uploadImages])
 
         switch result {
         case .success(let response):
-            break
+            isloadImageAWS = true
         case .failure(let error):
             await MainActor.run {
                 self.errorMessage = error.localizedDescription
             }
+            isloadImageAWS = false
         }
     }
 }

--- a/Treehouse/Treehouse/Presentation/Auth/RegisterScene/Views/SetMemberBioView.swift
+++ b/Treehouse/Treehouse/Presentation/Auth/RegisterScene/Views/SetMemberBioView.swift
@@ -36,7 +36,7 @@ struct SetMemberBioView: View {
             .padding(.bottom, SizeLiterals.Screen.screenHeight * 39/852)
             .fixedSize(horizontal: false, vertical: true)
             
-            Image(uiImage: viewModel.profileImage?[0] ?? .imgUser1)
+            Image(uiImage: viewModel.profileImage, defaultImage: .imgUser1)
                 .resizable()
                 .aspectRatio(contentMode: .fill)
                 .clipShape(Circle())

--- a/Treehouse/Treehouse/Presentation/Auth/RegisterScene/Views/SetMemberProfileImage.swift
+++ b/Treehouse/Treehouse/Presentation/Auth/RegisterScene/Views/SetMemberProfileImage.swift
@@ -61,8 +61,7 @@ struct SetMemberProfileImage: View {
             
             Button(action: {
                 Task {
-                    let result = await viewModel.presignedURL()
-                    if result {
+                    if await viewModel.presignedURL() {
                         await viewModel.loadImageAWS()
                     }
                 }
@@ -117,18 +116,18 @@ private extension SetMemberProfileImage {
             Image(.imgBackground)
                 .aspectRatio(contentMode: .fill)
 
-            if photoPickerManager.selectedImages.count != 0 {
+            if let selecteImage = photoPickerManager.selectedImages.first {
                 ZStack {
                     Image(.imgUserRing)
                     
-                    Image(uiImage: photoPickerManager.selectedImages[0])
+                    Image(uiImage: selecteImage)
                         .resizable()
                         .aspectRatio(contentMode: .fill)
                         .clipShape(Circle())
                         .frame(width: SizeLiterals.Screen.screenWidth * 130.24 / 393, height: SizeLiterals.Screen.screenHeight * 130.24 / 852)
                 }
                 .onAppear {
-                    viewModel.profileImage?.append(photoPickerManager.selectedImages[0])
+                    viewModel.profileImage = selecteImage
                 }
             } else {
                 Image(.imgUser2)

--- a/Treehouse/Treehouse/Presentation/Auth/RegisterScene/Views/ShowMemberProfileView.swift
+++ b/Treehouse/Treehouse/Presentation/Auth/RegisterScene/Views/ShowMemberProfileView.swift
@@ -141,7 +141,7 @@ extension ShowMemberProfileView {
                 
                 Circle().fill(.treePale)
                 
-                Image(uiImage: viewModel.profileImage?.first ?? .imgUser1)
+                Image(uiImage: viewModel.profileImage, defaultImage: .imgUser1)
                     .resizable()
                     .scaledToFill()
                     .frame(width: 99, height: 99)


### PR DESCRIPTION
## 📟 관련 이슈
- Resolved: #85 

## 👷 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
- PhotoPickerManager 에서 이미지 선택 시 downsample 메서드로 이미지 크기 줄이는 로직 추가
- 로그인 API 의 반환 DTO 데이터 구조 변경
- 회원 가입에서 Image 관련 로직 변경 ( 데이터 없을 때 기본 이미지 설정 )

## 🚨 참고 사항
#### `PhotoPickerManager`
``` swift
func resizeImageInParallel(images: [UIImage]) async -> [UIImage] {
    var resizeImages = images
    
    await withTaskGroup(of: (Int, UIImage).self) { group in
        for (index, image) in images.enumerated() {
            group.addTask {
                let result = await self.resizeImage(image: image)
                return (index, result)
            }
        }
        
        for await (index, image) in group {
            print(image.pngData()!)
            resizeImages[index] = image
        }
    }
    
    return resizeImages
}

Task {
    let resizedImages = await self.resizeImageInParallel(images: images)
    self.parent.selectedImages = resizedImages
}
``` 

유저 프로필 이미지나 글을 올리는 이미지의 크기를 줄여 메모리의 사용량을 줄일 수 있는 로직을 추가했습니다. 
이미지를 선택하는 PhotoPickerManager 에서 이미지를 선택 시 이미지의 크기를 줄이게 됩니다. 
해당 동작을 비동기처리를 해야하지만 여러 장일 수 있기 때문에 한장씩 처리를 하게 된다면 더욱 오래걸릴 수 있습니다.

다음과 같은이유로 withTaskGroup 을 통해 비동기 작업을 병렬로 실행하여 여러개의 이미지를 한번에 리사이징 합니다. 

여기서 중요한점은 비동기 작업은 끝나는 시점이 다르기 때문에 배열에 담긴 순서가 다를 수 있습니다. 
알맞는 순서로 다시 이미지를 넣기 위해서 반복문 로직을 추가했습니다.

<Br>

#### `Image+`

```  swift
init(uiImage: UIImage?, defaultImage: ImageResource) {
        if let uiImage = uiImage {
            self = Image(uiImage: uiImage)
        } else {
            self = Image(defaultImage)
        }
    }

/// 이전
Image(uiImage: viewModel.profileImage ?? [사용할 이미지])

/// 사용법
Image(uiImage: viewModel.profileImage, defaultImage: .imgUser1)
```

다음과 같이 Image 에 대한 데이터가 없을때 기본으로 보여줄 이미지를 설정하기 굉장히 힘듭니다. 
매사 데이터가 존재하는지 확인을 해야하기 때문에 초기화 시 데이터의 유무를 판단하고 기본 이미지를 설정하게 됩니다.

<br>

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
