### PR TITLE
[Feat] #98 - ImageDetailCarouselView 수정 및 사진 띄우기 로직 추가

### DIFF
--- a/Treehouse/Treehouse/Global/Components/CustomAsyncImage.swift
+++ b/Treehouse/Treehouse/Global/Components/CustomAsyncImage.swift
@@ -21,6 +21,21 @@ struct CustomAsyncImage: View {
     var type: ImageType
     var width: CGFloat
     var height: CGFloat
+    var onImageLoaded: ((Image) -> Void)?
+    
+    init(url: String, type: ImageType, width: CGFloat, height: CGFloat) {
+        self.url = url
+        self.type = type
+        self.width = width
+        self.height = height
+    }
+    
+    init(url: String, type: ImageType, width: CGFloat, height: CGFloat, onImageLoaded: @escaping (Image) -> Void) {
+        self.init(url: url, type: type, width: width, height: height)
+        if type == .postImage {
+            self.onImageLoaded = onImageLoaded
+        }
+    }
     
     var body: some View {
         AsyncImage(url: URL(string: url)) { phase in
@@ -29,6 +44,12 @@ struct CustomAsyncImage: View {
                 image
                     .resizable()
                     .aspectRatio(contentMode: .fill)
+                    .onAppear {
+                        print("Image 로드 됨")
+                        if type == .postImage {
+                            onImageLoaded?(image)
+                        }
+                    }
                    
             case .failure(_):
                 Image(systemName: "exclamationmark.icloud.fill")
@@ -69,6 +90,6 @@ struct CustomAsyncImage: View {
     }
 }
 
-#Preview {
-    CustomAsyncImage(url: "", type: .treehouseImage, width: 36, height: 36)
-}
+//#Preview {
+//    CustomAsyncImage(url: "", type: .treehouseImage, width: 36, height: 36)
+//}

--- a/Treehouse/Treehouse/Presentation/Feed/FeedScene/Views/ImageDetailCarouselView.swift
+++ b/Treehouse/Treehouse/Presentation/Feed/FeedScene/Views/ImageDetailCarouselView.swift
@@ -11,45 +11,32 @@ struct ImageDetailCarouselView: View {
     
     // MARK: - State Property
     
-    @State private var selectedIndex: Int
-    
-    // MARK: - Property
-    
-    let images: [String]
     @Environment(\.presentationMode) var presentationMode
-    
-    // MARK: - Initialize
-    
-    init(images: [String], selectedIndex: Int) {
-        self.images = images
-        self._selectedIndex = State(initialValue: selectedIndex)
-    }
+    @State var selectedIndex: Int
+    @Binding var images: [(Int,Image)]
     
     // MARK: - View
     
     var body: some View {
         NavigationStack {
-            ScrollView(.horizontal) {
-                LazyHStack(spacing: 0) {
-                    ForEach(images, id: \.self) { image in
-                        Image(image)
-                            .resizable()
-                            .frame(width: 393, height: 393)
-                    }
+            TabView(selection: $selectedIndex) {
+                ForEach(0..<images.count, id: \.self) { imageIndex in
+                    images[imageIndex].1
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .padding(.horizontal, 5)
+                        .frame(maxWidth:.infinity)
+                        .padding(.bottom, 30)
+                        .tag(imageIndex)
                 }
             }
             .background(.grayscaleBlack)
-            .scrollTargetBehavior(.paging)
-            .scrollIndicators(.hidden)
-            .gesture(
-                DragGesture()
-                    .onEnded { value in
-                        if value.translation.height > 100 {
-                            presentationMode.wrappedValue.dismiss()
-                        }
-                    }
-            )
+            .tabViewStyle(PageTabViewStyle(indexDisplayMode: .never))
             .navigationBarTitleDisplayMode(.inline)
+            .navigationBarBackButtonHidden()
+            .onAppear {
+                images = images.sorted(by: {$0.0 < $1.0} )
+            }
             .toolbar {
                 ToolbarItem(placement: .topBarLeading) {
                     Button(action: {
@@ -59,19 +46,27 @@ struct ImageDetailCarouselView: View {
                             .foregroundColor(.grayscaleWhite)
                     }
                 }
-                
+
                 ToolbarItem(placement: .principal) {
-                    Text("\(selectedIndex + 1)/\(images.count)")
-                        .font(.fontGuide(.body2))
+                    Text("\(selectedIndex + 1) / \(images.count)")
+                        .fontWithLineHeight(fontLevel: .body2)
                         .foregroundStyle(.grayscaleWhite)
                 }
             }
         }
+        .gesture(
+            DragGesture()
+              .onEnded { value in
+                  if value.translation.height > 100 {
+                      presentationMode.wrappedValue.dismiss()
+                  }
+              }
+        )
     }
 }
 
 // MARK: - Preview
 
-#Preview {
-    ImageDetailCarouselView(images: [], selectedIndex: 1)
-}
+//#Preview {
+//    ImageDetailCarouselView(images: [], selectedIndex: 1)
+//}

--- a/Treehouse/Treehouse/Presentation/Feed/FeedScene/Views/SinglePostView.swift
+++ b/Treehouse/Treehouse/Presentation/Feed/FeedScene/Views/SinglePostView.swift
@@ -24,6 +24,12 @@ struct SinglePostView: View {
     @Environment (ViewRouter.self) var viewRouter
     @Environment (FeedViewModel.self) var feedViewModel
     
+    @State private var selectedImage: Int? = nil
+    @State private var viewModel = SheetActionViewModel()
+    
+    @State private var loadedImage = [(Int,Image)]()
+    @State private var isDetailImage = false
+    
     // MARK: - Property
     
     let postId: Int?
@@ -33,10 +39,7 @@ struct SinglePostView: View {
     let memberProfile: MemberProfileEntity
     var postType: PostType
     
-    // MARK:  - State Property
-    
-    @State private var selectedImage: SelectedImage? = nil
-    @State private var viewModel = SheetActionViewModel()
+    // MARK:  - init
     
     init(postId: Int?, sentTime: String, postContent: String, postImageURLs: [String], memberProfile: MemberProfileEntity, postType: PostType) {
         self.postId = postId
@@ -110,8 +113,8 @@ struct SinglePostView: View {
                 
                 contentImageView()
             }
-            .fullScreenCover(item: $selectedImage) { selectedImage in
-                ImageDetailCarouselView(images: postImageURLs, selectedIndex: selectedImage.id)
+            .fullScreenCover(isPresented: $isDetailImage) {
+                ImageDetailCarouselView(selectedIndex: selectedImage ?? 0, images: $loadedImage)
             }
         }
         // 바텀시트 표출
@@ -162,10 +165,12 @@ extension SinglePostView {
         CustomAsyncImage(url: postImageURLs.first ?? "", 
                          type: .postImage,
                          width: 314,
-                         height: 200)
+                         height: 200) { image in
+                            self.loadedImage.append((0, image))
+                         }
             .onTapGesture {
                 if postType == .DetailView {
-                    selectedImage = SelectedImage(id: 0)
+                    isDetailImage.toggle()
                 } else {
                     feedViewModel.currentPostId = postId
                     viewRouter.push(FeedRouter.postDetailView)
@@ -182,10 +187,13 @@ extension SinglePostView {
                 ForEach(0..<postImageURLs.count, id: \.self) { index in
                     CustomAsyncImage(url: postImageURLs[index], type: .postImage,
                                      width: 206,
-                                     height: 200)
+                                     height: 200) { image in
+                                        self.loadedImage.append((index, image))
+                                     }
                         .onTapGesture {
                             if postType == .DetailView {
-                                selectedImage = SelectedImage(id: index)
+                                isDetailImage.toggle()
+                                selectedImage = index
                             } else {
                                 feedViewModel.currentPostId = postId
                                 viewRouter.push(FeedRouter.postDetailView)


### PR DESCRIPTION
## 📟 관련 이슈
- Resolved: #98 

## 👷 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
- CustomAsyncImage 에서 로딩 된 Image 를 추출하는 로직 추가
- ImageDetailCarouselView 를 TabView 의 PageTabViewStyle 로 구현
- SinglePostView 에서 ImageDetailCarouselView 을 띄우기 위한 로직 수정

<br>

## 📸 스크린샷
https://github.com/user-attachments/assets/50bbafe0-b834-41aa-99cd-c6ec90a427f1

<br>

## 🚨 참고 사항
<!-- 참고 사항을 적어주세요. 없으면 지워주세요. -->

### ` CustomAsyncImage ` 에서 Image 추출

``` swift
struct CustomAsyncImage: View {

    var onImageLoaded: ((Image) -> Void)?

    AsyncImage(url: URL(string: url)) { phase in
            switch phase {
            case .success(let image):
                image
                    .resizable()
                    .aspectRatio(contentMode: .fill)
                    .onAppear {
                        if type == .postImage {
                            onImageLoaded?(image)
                        }
                    }
    // ....
}
```

현재 구현되어있는 `CustomAsyncImage` 는 url 로 되어있는 Image 를 다운 받기 위해 만들어진 View 입니다. 
성공했을 때 Image 를 반환하게 되는데 Image 를 사용할 때마다 로드 할 수 없으므로 Image 데이터를 갖고 있어야 하는데 기존에는 불가했습니다.

다음과 같이 클로저를 통해 로드된 Image 를 반환하고 해당 View 를 사용한 부모 View 에서 Image 를 전달받을 수 있도록 구현했습니다.

<br>




## ✅ Checklist
- [X] 필요없는 주석, 프린트문 제거했는지 확인
- [X] 컨벤션 지켰는지 확인
