### PR TITLE
[Feat] #105 - URLCache 와 ImageLoader 를 통해 네트워크 사용량 감소 구현

### DIFF
--- a/Treehouse/Treehouse.xcodeproj/project.pbxproj
+++ b/Treehouse/Treehouse.xcodeproj/project.pbxproj
@@ -197,6 +197,8 @@
 		3FE944122BD3ADFF00C3A869 /* ReceivedInvitationModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FE944112BD3ADFF00C3A869 /* ReceivedInvitationModel.swift */; };
 		3FE944152BD63FF600C3A869 /* ReceivedInvitationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FE944142BD63FF600C3A869 /* ReceivedInvitationViewModel.swift */; };
 		3FE944172BD645C300C3A869 /* ReceivedInvitationRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FE944162BD645C300C3A869 /* ReceivedInvitationRowView.swift */; };
+		3FEEF75E2C69B27A002CBA53 /* ImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEEF75D2C69B27A002CBA53 /* ImageLoader.swift */; };
+		3FEEF7602C69F7B7002CBA53 /* ReadPageFeedPostUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEEF75F2C69F7B7002CBA53 /* ReadPageFeedPostUseCase.swift */; };
 		3FF106FA2BEA077E00C52908 /* BaseRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FF106F92BEA077E00C52908 /* BaseRequest.swift */; };
 		3FF106FC2BEA078D00C52908 /* BaseResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FF106FB2BEA078C00C52908 /* BaseResponse.swift */; };
 		3FF106FE2BEA079500C52908 /* HttpMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FF106FD2BEA079500C52908 /* HttpMethod.swift */; };
@@ -476,6 +478,8 @@
 		3FE944112BD3ADFF00C3A869 /* ReceivedInvitationModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceivedInvitationModel.swift; sourceTree = "<group>"; };
 		3FE944142BD63FF600C3A869 /* ReceivedInvitationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceivedInvitationViewModel.swift; sourceTree = "<group>"; };
 		3FE944162BD645C300C3A869 /* ReceivedInvitationRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceivedInvitationRowView.swift; sourceTree = "<group>"; };
+		3FEEF75D2C69B27A002CBA53 /* ImageLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageLoader.swift; sourceTree = "<group>"; };
+		3FEEF75F2C69F7B7002CBA53 /* ReadPageFeedPostUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadPageFeedPostUseCase.swift; sourceTree = "<group>"; };
 		3FF106F92BEA077E00C52908 /* BaseRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseRequest.swift; sourceTree = "<group>"; };
 		3FF106FB2BEA078C00C52908 /* BaseResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseResponse.swift; sourceTree = "<group>"; };
 		3FF106FD2BEA079500C52908 /* HttpMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HttpMethod.swift; sourceTree = "<group>"; };
@@ -886,6 +890,7 @@
 				00CF35922BC2E1DA00D9E332 /* Literals */,
 				00CF35912BC2DFA800D9E332 /* Resources */,
 				00CF35B22BC3060E00D9E332 /* Extension */,
+				3FEEF75D2C69B27A002CBA53 /* ImageLoader.swift */,
 			);
 			path = Global;
 			sourceTree = "<group>";
@@ -1198,6 +1203,7 @@
 			children = (
 				3FA175DB2C1AC2FD00A57987 /* PresignedURLUseCase.swift */,
 				3FF48FD52C4E3C3A00A6DD8A /* ReadFeedPostUseCase.swift */,
+				3FEEF75F2C69F7B7002CBA53 /* ReadPageFeedPostUseCase.swift */,
 				3F8530ED2C5382E3003FA07A /* ReadDetailFeedPostUseCase.swift */,
 				3F8530EF2C5639E3003FA07A /* CreateReactionToPostUseCase.swift */,
 				3F8AE7052C59E11D00E999C4 /* CreateFeedPostsUseCase.swift */,
@@ -2016,6 +2022,7 @@
 				3FF48FEC2C50E98600A6DD8A /* PostCreateTreehouseRequestDTO.swift in Sources */,
 				947326192C1C8D640030A182 /* EditPostPopupView.swift in Sources */,
 				00CF35822BC291FA00D9E332 /* TreehouseApp.swift in Sources */,
+				3FEEF7602C69F7B7002CBA53 /* ReadPageFeedPostUseCase.swift in Sources */,
 				3FF107232BEA0AA700C52908 /* PostRegisterTreeMemberResponseDTO.swift in Sources */,
 				3FC1FB342BD8922B00AAE53F /* CommentModel.swift in Sources */,
 				3FC1FB302BD7749000AAE53F /* EmojiListView.swift in Sources */,
@@ -2042,6 +2049,7 @@
 				3F81715F2C4384E600CEE21E /* ExistsUserLoginUserCase.swift in Sources */,
 				94D388D92C287DC00058231B /* SendInvitationView.swift in Sources */,
 				94D1001D2C0CC60A00025D43 /* PhotoPickerManager.swift in Sources */,
+				3FEEF75E2C69B27A002CBA53 /* ImageLoader.swift in Sources */,
 				3FF48FF42C50ED1300A6DD8A /* MemberAPI.swift in Sources */,
 				00C2F5692C16F82F0009C6A1 /* MemberProfileView.swift in Sources */,
 				3F8530F42C567705003FA07A /* PostCreateReplyCommentResponseDTO.swift in Sources */,
@@ -2291,8 +2299,8 @@
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = "Launch Screen.storyboard";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				IPHONEOS_DEPLOYMENT_TARGET = 17.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -2327,8 +2335,8 @@
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = "Launch Screen.storyboard";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				IPHONEOS_DEPLOYMENT_TARGET = 17.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/Treehouse/Treehouse/Application/TreehouseApp.swift
+++ b/Treehouse/Treehouse/Application/TreehouseApp.swift
@@ -16,6 +16,12 @@ class AppDelegate: NSObject, UIApplicationDelegate {
 
     return true
   }
+    
+    func applicationWillTerminate(_ application: UIApplication) {
+        // 앱이 종료될 때 캐시 제거
+        URLCache.shared.removeAllCachedResponses()
+        print("모든 캐시가 제거되었습니다.")
+    }
 }
 
 @main
@@ -27,6 +33,7 @@ struct TreehouseApp: App {
     
     init() {
         configureNavigationBar()
+        configureURLCache()
     }
     
     var body: some Scene {
@@ -39,6 +46,9 @@ struct TreehouseApp: App {
                     SetPhoneNumberView()
                         .environment(viewRouter)
                 }
+            }
+            .onAppear {
+                print("\(URLCache.shared.memoryCapacity / 1024 / 1024) MB")
             }
         }
     }
@@ -66,5 +76,19 @@ struct TreehouseApp: App {
         UINavigationBar.appearance().standardAppearance = appearance
         UINavigationBar.appearance().compactAppearance = appearance
         UINavigationBar.appearance().scrollEdgeAppearance = appearance
+    }
+    
+    private func configureURLCache() {
+        
+        let totalMemory = ProcessInfo.processInfo.physicalMemory
+        let deviceAdjustedLimit = Int(Double(totalMemory) * 0.03)
+        
+        let memoryCapacity = 150 * 1024 * 1024 // 150 MB
+        let diskCapacity = 100 * 1024 * 1024 // 100 MB
+        
+        let cacheLimit = min(memoryCapacity, deviceAdjustedLimit)
+        
+        let cache = URLCache(memoryCapacity: cacheLimit, diskCapacity: diskCapacity, diskPath: "myImages")
+        URLCache.shared = cache
     }
 }

--- a/Treehouse/Treehouse/Data/Repositories/FeedRepositoryImpl.swift
+++ b/Treehouse/Treehouse/Data/Repositories/FeedRepositoryImpl.swift
@@ -34,6 +34,18 @@ final class FeedRepositoryImpl: FeedRepositoryProtocol {
         }
     }
     
+    /// Feed 의 게시글을 페이지네이션으로  불러오기 위한 API
+    func getPageReadFeedPost(treehouseId: Int, page: Int) async -> Result<[GetReadFeedPostListResponseEntity], NetworkError>{
+        do {
+            let response = try await feedService.getPageReadFeedPost(treehouseId: treehouseId, page: page)
+            return .success(response.map { $0.toDomain() })
+        } catch let error as NetworkError {
+            return .failure(error)
+        } catch {
+            return .failure(NetworkError.unknown)
+        }
+    }
+    
     /// Feed 에 게시글을 작성하기 위한 API
     func postCreateFeedPosts(treehouseId: Int, requestBody: PostCreateFeedPostsRequestDTO) async -> Result<CreateFeedPostsResponseResponseEntity, NetworkError>{
         do {

--- a/Treehouse/Treehouse/Domain/RepositoryProtocol/FeedRepositoryProtocol.swift
+++ b/Treehouse/Treehouse/Domain/RepositoryProtocol/FeedRepositoryProtocol.swift
@@ -10,6 +10,7 @@ import Foundation
 protocol FeedRepositoryProtocol {
     func postPresignedURL(treehouseId: Int, fileName: String, fileSize: Int) async -> Result<PresignedURLResponseEntity,NetworkError>
     func getReadPost(treehouseId: Int) async -> Result<[GetReadFeedPostListResponseEntity], NetworkError>
+    func getPageReadFeedPost(treehouseId: Int, page: Int) async -> Result<[GetReadFeedPostListResponseEntity], NetworkError>
     func postCreateFeedPosts(treehouseId: Int, requestBody: PostCreateFeedPostsRequestDTO) async -> Result<CreateFeedPostsResponseResponseEntity, NetworkError>
     func patchUpdateFeedPost(treehouseId: Int, postId: Int, context: String) async -> Result<UpdateFeedPostResponseEntity, NetworkError>
     func getReadDetailPost(treehouseId: Int, postId: Int) async -> Result<GetReadDetailFeedPostResponseEntity, NetworkError>

--- a/Treehouse/Treehouse/Domain/UseCases/Feed/ReadPageFeedPostUseCase.swift
+++ b/Treehouse/Treehouse/Domain/UseCases/Feed/ReadPageFeedPostUseCase.swift
@@ -1,0 +1,24 @@
+//
+//  ReadPageFeedPostUseCase.swift
+//  Treehouse
+//
+//  Created by ParkJunHyuk on 8/12/24.
+//
+
+import Foundation
+
+protocol GetPageReadFeedPostUseCaseProtocol {
+    func execute(treehouseId: Int, page: Int) async -> Result<[GetReadFeedPostListResponseEntity], NetworkError>
+}
+
+final class ReadPageFeedPostUseCase: GetPageReadFeedPostUseCaseProtocol {
+    private let repository: FeedRepositoryProtocol
+    
+    init(repository: FeedRepositoryProtocol) {
+        self.repository = repository
+    }
+    
+    func execute(treehouseId: Int, page: Int) async -> Result<[GetReadFeedPostListResponseEntity], NetworkError> {
+        return await repository.getPageReadFeedPost(treehouseId: treehouseId, page: page)
+    }
+}

--- a/Treehouse/Treehouse/Global/Components/CustomAsyncImage.swift
+++ b/Treehouse/Treehouse/Global/Components/CustomAsyncImage.swift
@@ -17,80 +17,81 @@ enum ImageType {
 }
 
 struct CustomAsyncImage: View {
+    @State var imageLoader: ImageLoader
     
     var url: String
     var type: ImageType
     var width: CGFloat
     var height: CGFloat
-    var onImageLoaded: ((Image) -> Void)?
+    var onImageLoaded: ((UIImage) -> Void)?
     
     init(url: String, type: ImageType, width: CGFloat, height: CGFloat) {
         self.url = url
         self.type = type
         self.width = width
         self.height = height
+        self._imageLoader = State(wrappedValue: ImageLoader(url: url))
     }
     
-    init(url: String, type: ImageType, width: CGFloat, height: CGFloat, onImageLoaded: @escaping (Image) -> Void) {
+    init(url: String, type: ImageType, width: CGFloat, height: CGFloat, onImageLoaded: @escaping (UIImage) -> Void) {
         self.init(url: url, type: type, width: width, height: height)
         if type == .postImage {
             self.onImageLoaded = onImageLoaded
         }
     }
     
+    @ViewBuilder
     var body: some View {
-        AsyncImage(url: URL(string: url)) { phase in
-            switch phase {
+        Group {
+            switch imageLoader.state {
+            case .loading:
+                ProgressView()
+                    
             case .success(let image):
-                image
+                Image(uiImage: image)
                     .resizable()
                     .aspectRatio(contentMode: .fill)
                     .onAppear {
-                        print("Image 로드 됨")
                         if type == .postImage {
                             onImageLoaded?(image)
                         }
                     }
-                   
-            case .failure(_):
-                Image(systemName: "exclamationmark.icloud.fill")
-                    .resizable()
-                    .scaledToFit()
-                
-            case .empty:
-                if URL(string: url) == nil || url.isEmpty {
-                    switch type {
-                    case .memberProfileImage:
-                        Image(.imgUser)
-                            .resizable()
-                            .scaledToFit()
-                    case .postMemberProfileImage, .notiProfileImage:
-                        Image(.imgProfile)
-                            .resizable()
-                            .scaledToFit()
-                    case .postImage:
-                        Image(.imgDummy)
-                            .resizable()
-                            .scaledToFit()
-                    case .treehouseImage:
-                        Image(.imgGroup)
-                            .resizable()
-                            .scaledToFit()
-                    case .postTreehouseImage:
-                        Image(.imgGroup)
-                            .resizable()
-                            .scaledToFit()
-                    }
-                }
-            @unknown default:
-                ProgressView()
+            case .failure:
+                failurebackImage
             }
         }
         .frame(width: SizeLiterals.Screen.screenWidth * width / 393, height: SizeLiterals.Screen.screenHeight * height / 852)
         .cornerRadius(6.0)
+        .onAppear {
+            Task {
+                await imageLoader.fetch()
+            }
+        }
+    }
+    
+    @ViewBuilder
+    private var failurebackImage: some View {
+        switch type {
+        case .memberProfileImage:
+            Image(.imgUser)
+                .resizable()
+                .scaledToFit()
+        case .postMemberProfileImage, .notiProfileImage:
+            Image(.imgProfile)
+                .resizable()
+                .scaledToFit()
+        case .postImage:
+            Image(.imgDummy)
+                .resizable()
+                .scaledToFit()
+        case .treehouseImage, .postTreehouseImage:
+            Image(.imgGroup)
+                .resizable()
+                .scaledToFit()
+        }
     }
 }
 
-//#Preview {
-//    CustomAsyncImage(url: "", type: .treehouseImage, width: 36, height: 36)
-//}
+#Preview {
+    CustomAsyncImage(url: "", type: .treehouseImage, width: 36, height: 36)
+}

--- a/Treehouse/Treehouse/Global/Components/LottieView.swift
+++ b/Treehouse/Treehouse/Global/Components/LottieView.swift
@@ -31,11 +31,12 @@ struct LottieView: UIViewRepresentable {
             animationView.heightAnchor.constraint(equalTo: view.heightAnchor)
         ])
         
+        animationView.play()
+        
         return view
     }
 
     func updateUIView(_ uiView: UIView, context: UIViewRepresentableContext<LottieView>) {
-        animationView.play()
     }
 }
 

--- a/Treehouse/Treehouse/Global/Extension/UIImage+.swift
+++ b/Treehouse/Treehouse/Global/Extension/UIImage+.swift
@@ -18,18 +18,41 @@ extension UIImage {
         }
 
         let maxDimensionInPixels = max(pointSize.width, pointSize.height) * scale
-        let downsampleOptions = [
-            kCGImageSourceCreateThumbnailFromImageAlways: true,
-            kCGImageSourceShouldCacheImmediately: true,
-            kCGImageSourceCreateThumbnailWithTransform: true,
-            kCGImageSourceThumbnailMaxPixelSize: maxDimensionInPixels * 3
-        ] as CFDictionary
-
-        guard let downsampledImage = CGImageSourceCreateThumbnailAtIndex(imageSource, 0, downsampleOptions) else {
-            return nil
+        print("원본 사이즈:", imageData)
+        var count: CGFloat = 1
+        var low: CGFloat = maxDimensionInPixels * count
+        var high: CGFloat = maxDimensionInPixels * 10
+        var resultImage: UIImage?
+        
+        while low <= high {
+            let downsampleOptions = [
+                kCGImageSourceCreateThumbnailFromImageAlways: true,
+                kCGImageSourceShouldCacheImmediately: true,
+                kCGImageSourceCreateThumbnailWithTransform: true,
+                kCGImageSourceThumbnailMaxPixelSize: low
+            ] as CFDictionary
+            
+            guard let downsampledImage = CGImageSourceCreateThumbnailAtIndex(imageSource, 0, downsampleOptions) else {
+                return nil
+            }
+            
+            let currentImage = UIImage(cgImage: downsampledImage)
+            
+            guard let currentImageData = currentImage.pngData() else {
+                return nil
+            }
+            
+            print(currentImageData)
+            
+            if currentImageData.count <= 3000000 {
+                resultImage = currentImage
+                count += 1
+                low = maxDimensionInPixels * count
+            } else {
+                break
+            }
         }
-
-        return UIImage(cgImage: downsampledImage)
+        return resultImage
     }
     
     func getImageBitSize() -> Int {

--- a/Treehouse/Treehouse/Global/ImageLoader.swift
+++ b/Treehouse/Treehouse/Global/ImageLoader.swift
@@ -1,0 +1,73 @@
+//
+//  ImageLoader.swift
+//  Treehouse
+//
+//  Created by ParkJunHyuk on 8/12/24.
+//
+
+import Foundation
+import Observation
+import SwiftUI
+
+struct CacheUsage {
+    let memoryUsage: Int
+    let diskUsage: Int
+    
+    var memoryUsageMB: Double {
+        return Double(memoryUsage) / (1024 * 1024)
+    }
+    
+    var diskUsageMB: Double {
+        return Double(diskUsage) / (1024 * 1024)
+    }
+}
+
+@Observable
+final class ImageLoader {
+    var image: UIImage?
+    private var url: String?
+    var state: LoadState = .loading
+    
+    enum LoadState {
+       case loading
+       case success(UIImage)
+       case failure
+   }
+    
+    static func getCurrentCacheUsage() -> CacheUsage {
+           let cache = URLCache.shared
+           return CacheUsage(
+               memoryUsage: cache.currentMemoryUsage,
+               diskUsage: cache.currentDiskUsage
+           )
+       }
+    
+    init(url: String?) {
+        self.url = url
+    }
+    
+    @MainActor
+    func fetch() async {
+        guard let url = url, let fetchURL = URL(string: url) else {
+            state = .failure
+            return
+        }
+        
+        let request = URLRequest(url: fetchURL, cachePolicy: .returnCacheDataElseLoad)
+        let usage = ImageLoader.getCurrentCacheUsage()
+        
+        do {
+            let (data, _) = try await URLSession.shared.data(for: request)
+            if let image = UIImage(data: data) {
+                state = .success(image)
+            } else {
+                state = .failure
+            }
+            print("메모리 캐시: \(String(format: "%.2f", usage.memoryUsageMB)) MB")
+            print("디스크 캐시: \(String(format: "%.2f", usage.diskUsageMB)) MB")
+        } catch {
+            print("Error loading image: \(error)")
+            state = .failure
+        }
+    }
+}

--- a/Treehouse/Treehouse/Global/SwiftData/UserInfoDataSource.swift
+++ b/Treehouse/Treehouse/Global/SwiftData/UserInfoDataSource.swift
@@ -38,11 +38,6 @@ final class UserInfoDataSource {
     func fetchItem() -> UserInfoData? {
         do {
             let data = try modelContext.fetch(FetchDescriptor<UserInfoData>())
-            data.forEach {
-                print($0.userName)
-            }
-            print("유저 정보 불러오기: \(String(describing: data.first?.userName))")
-
             return data.first
         } catch {
             fatalError(error.localizedDescription)

--- a/Treehouse/Treehouse/Global/SwiftData/UserInfoViewModel.swift
+++ b/Treehouse/Treehouse/Global/SwiftData/UserInfoViewModel.swift
@@ -18,7 +18,10 @@ final class UserInfoViewModel: BaseViewModel {
 
     var userInfo: UserInfoData? {
         didSet {
-            print("새로 바뀐 값: \(userInfo)")
+            print("유저 id: \(userInfo?.userId)")
+            print("유저 이름: \(userInfo?.userName)")
+            print("유저 프로필 URL: \(userInfo?.profileImageUrl)")
+            print("가입한 Treehouse: \(userInfo?.treehouses)")
         }
     }
 
@@ -30,6 +33,7 @@ final class UserInfoViewModel: BaseViewModel {
     /// UserInfoData 를 처음으로 만들기 위한 메서드
     func createData(newData: UserInfoData) async -> Bool {
         print("User Data 저장")
+        removeData()
         userInfo = newData
         return insertData(data: newData)
     }
@@ -92,6 +96,7 @@ private extension UserInfoViewModel {
 
     func removeData() {
         guard let data = userInfo else { return }
+        print("데이터 삭제")
         dataSource.removeUserInfo(data: data)
         userInfo = nil
     }

--- a/Treehouse/Treehouse/Info.plist
+++ b/Treehouse/Treehouse/Info.plist
@@ -6,8 +6,6 @@
 	<string>$(ACCESS_TOKEN_KEY)</string>
 	<key>BASE_URL</key>
 	<string>$(BASE_URL)</string>
-	<key>WEB_FRONT_URL</key>
-	<string>$(WEB_FRONT_URL)</string>
 	<key>LOGIN_KEY</key>
 	<string>$(LOGIN_KEY)</string>
 	<key>REFRESH_TOKEN_KEY</key>
@@ -18,5 +16,7 @@
 		<string>Pretendard-Regular.otf</string>
 		<string>Pretendard-SemiBold.otf</string>
 	</array>
+	<key>WEB_FRONT_URL</key>
+	<string>$(WEB_FRONT_URL)</string>
 </dict>
 </plist>

--- a/Treehouse/Treehouse/Network/Feed/FeedAPI.swift
+++ b/Treehouse/Treehouse/Network/Feed/FeedAPI.swift
@@ -9,6 +9,7 @@ import Foundation
 
 enum FeedAPI {
     case getReadFeedPostsList(treehouseId: Int)
+    case getPageReadFeedPostsList(treehouseId: Int, page: Int)
     case postCreateFeedPosts(treehouseId: Int, requestBody: PostCreateFeedPostsRequestDTO)
     case getReadDetailFeedPosts(treehouseId: Int, postId: Int)
     case deleteFeedPost(treehouseId: Int, postId: Int)
@@ -21,7 +22,7 @@ enum FeedAPI {
 extension FeedAPI: BaseRequest {
     var path: String {
         switch self {
-        case .getReadFeedPostsList(treehouseId: let treehouseId):
+        case .getReadFeedPostsList(treehouseId: let treehouseId), .getPageReadFeedPostsList(treehouseId: let treehouseId, _):
             return "treehouses/\(treehouseId)/feeds"
         case .postCreateFeedPosts(treehouseId: let treehouseId, _):
             return "treehouses/\(treehouseId)/feeds/posts"
@@ -40,7 +41,7 @@ extension FeedAPI: BaseRequest {
     
     var httpMethod: HttpMethod {
         switch self {
-        case .getReadFeedPostsList, .getReadDetailFeedPosts:
+        case .getReadFeedPostsList, .getPageReadFeedPostsList, .getReadDetailFeedPosts:
             return .get
         case .postCreateFeedPosts, .postReactionFeedPost, .postReportFeedPost, .postPresignedURL:
             return .post
@@ -57,7 +58,13 @@ extension FeedAPI: BaseRequest {
     
     var body: Data? { return .none }
 
-    var queryParameter: [String : Any]? { return .none }
+    var queryParameter: [String : Any]? {
+        switch self {
+        case .getPageReadFeedPostsList(_, let page):
+            return ["page": page]
+        default: return .none
+        }
+    }
     
     var requestBodyParameter: (any Codable)? {
         switch self {

--- a/Treehouse/Treehouse/Network/Feed/FeedService.swift
+++ b/Treehouse/Treehouse/Network/Feed/FeedService.swift
@@ -22,6 +22,17 @@ final class FeedService {
         return try await networkServiceManager.performRequest(with: urlRequest, decodingType: [GetReadFeedPostsListResponseDTO].self)
     }
     
+    /// Feed 의 게시글을 페이지네이션으로 읽어오는 API
+    func getPageReadFeedPost(treehouseId: Int, page: Int) async throws -> [GetReadFeedPostsListResponseDTO] {
+        let request = NetworkRequest(requestType: FeedAPI.getPageReadFeedPostsList(treehouseId: treehouseId, page: page))
+        
+        guard let urlRequest = request.request() else {
+            throw NetworkError.clientError(message: "Request 생성불가")
+        }
+        
+        return try await networkServiceManager.performRequest(with: urlRequest, decodingType: [GetReadFeedPostsListResponseDTO].self)
+    }
+    
     /// Feed 의 게시글을 작성하는 API
     func postCreateFeedPosts(treehouseId: Int, requestBody: PostCreateFeedPostsRequestDTO) async throws -> PostCreateFeedPostsResponseDTO {
         let request = NetworkRequest(requestType: FeedAPI.postCreateFeedPosts(treehouseId: treehouseId, requestBody: requestBody))

--- a/Treehouse/Treehouse/Presentation/Auth/RegisterScene/ViewModels/UserLoginViewModel.swift
+++ b/Treehouse/Treehouse/Presentation/Auth/RegisterScene/ViewModels/UserLoginViewModel.swift
@@ -51,7 +51,7 @@ extension UserLoginViewModel {
             KeychainHelper.shared.save(response.refreshToken, for: Config.refreshTokenKey)
             
             return UserInfoData(userId: response.userId,
-                                userName: "",
+                                userName: response.userName,
                                 profileImageUrl: response.profileImageUrl ?? "",
                                 treehouses: response.treehouseIdList, treehouseInfo: [])
             

--- a/Treehouse/Treehouse/Presentation/Auth/RegisterScene/ViewModels/UserSettingViewModel.swift
+++ b/Treehouse/Treehouse/Presentation/Auth/RegisterScene/ViewModels/UserSettingViewModel.swift
@@ -201,12 +201,11 @@ extension UserSettingViewModel {
     func registerTreeMember() async -> Bool {
         guard let treehouseId = treehouseId,
               let memberName = memberName,
-              let bio = bio,
-              let accessUrlImage = accessUrlImage.first else {
+              let bio = bio else {
             return false
         }
         
-        let result = await registerTreeMemberUseCase.execute(requestDTO: PostRegisterTreeMemberRequestDTO(treehouseId: treehouseId, userName: userName, memberName: memberName, bio: bio, profileImageURL: accessUrlImage))
+        let result = await registerTreeMemberUseCase.execute(requestDTO: PostRegisterTreeMemberRequestDTO(treehouseId: treehouseId, userName: userName, memberName: memberName, bio: bio, profileImageURL: accessUrlImage.first ?? "" ))
         
         switch result {
         case .success(let response):

--- a/Treehouse/Treehouse/Presentation/Feed/FeedContentScene/Views/CommentView.swift
+++ b/Treehouse/Treehouse/Presentation/Feed/FeedContentScene/Views/CommentView.swift
@@ -35,8 +35,11 @@ struct CommentView: View {
     
     var body: some View {
         HStack(alignment: .top, spacing: 0) {
-            Image(.icNotiMember)
-                .frame(width: 36, height: 36)
+            CustomAsyncImage(url: userProfile.memberProfileImageUrl ?? "",
+                              type: .postMemberProfileImage,
+                              width: 36,
+                              height: 36)
+                .clipShape(Circle())
                 .padding(.trailing, 10)
 //                .padding(.trailing, commentyType == .comment ? 8 : 10)
             

--- a/Treehouse/Treehouse/Presentation/Feed/FeedScene/Views/ImageDetailCarouselView.swift
+++ b/Treehouse/Treehouse/Presentation/Feed/FeedScene/Views/ImageDetailCarouselView.swift
@@ -13,7 +13,7 @@ struct ImageDetailCarouselView: View {
     
     @Environment(\.presentationMode) var presentationMode
     @State var selectedIndex: Int
-    @Binding var images: [(Int,Image)]
+    @Binding var images: [(Int,UIImage)]
     
     // MARK: - View
     
@@ -21,7 +21,7 @@ struct ImageDetailCarouselView: View {
         NavigationStack {
             TabView(selection: $selectedIndex) {
                 ForEach(0..<images.count, id: \.self) { imageIndex in
-                    images[imageIndex].1
+                    Image(uiImage: images[imageIndex].1)
                         .resizable()
                         .aspectRatio(contentMode: .fit)
                         .padding(.horizontal, 5)

--- a/Treehouse/Treehouse/Presentation/Feed/FeedScene/Views/PostDetailView.swift
+++ b/Treehouse/Treehouse/Presentation/Feed/FeedScene/Views/PostDetailView.swift
@@ -167,17 +167,16 @@ extension PostDetailView {
                 .frame(maxWidth: .infinity, maxHeight: 1)
                 .foregroundColor(.gray3)
             
-            HStack(alignment: .bottom, spacing: 10) {
+            HStack(alignment: .center, spacing: 10) {
                 CustomAsyncImage(url: userInfoViewModel.userInfo?.profileImageUrl ?? "",
                                  type: .postMemberProfileImage,
                                  width: 36,
                                  height: 36)
                     .clipShape(Circle())
-                    .padding(.bottom, 4)
                 
                 ZStack(alignment: .trailing) {
                     TextField("\(commentViewModel.createCommentMemberName)에게 댓글쓰기", text: $commentViewModel.postContent, axis: .vertical)
-                        .padding(EdgeInsets(top: 12.0, leading: 14.0, bottom: 12.0, trailing: 14.0))
+                        .padding(EdgeInsets(top: 12.0, leading: 14.0, bottom: 12.0, trailing: 50.0))
                         .fontWithLineHeight(fontLevel: .body5)
                         .tint(.treeGreen)
                         .foregroundColor(textFieldState.fontColor)
@@ -229,7 +228,7 @@ extension PostDetailView {
                 }
             }
             .padding(.leading, 16)
-            .padding(.top, 8)
+            .padding(.bottom, 8)
             .padding(.trailing, 16)
         }
         .background(.grayscaleWhite)

--- a/Treehouse/Treehouse/Presentation/Feed/FeedScene/Views/SinglePostView.swift
+++ b/Treehouse/Treehouse/Presentation/Feed/FeedScene/Views/SinglePostView.swift
@@ -27,7 +27,7 @@ struct SinglePostView: View {
     @State private var selectedImage: Int? = nil
     @State private var viewModel = SheetActionViewModel()
     
-    @State private var loadedImage = [(Int,Image)]()
+    @State private var loadedImage = [(Int,UIImage)]()
     @State private var isDetailImage = false
     
     // MARK: - Property
@@ -64,12 +64,8 @@ struct SinglePostView: View {
     var body: some View {
         ZStack {
             VStack(spacing: 0) {
-//                Rectangle()
-//                    .frame(maxWidth: .infinity, maxHeight: 1)
-//                    .foregroundColor(.gray3)
-                
                 HStack(alignment: .top, spacing: 10) {
-                    CustomAsyncImage(url: memberProfile.memberProfileImageUrl ?? "", 
+                    CustomAsyncImage(url: memberProfile.memberProfileImageUrl ?? "",
                                      type: .postMemberProfileImage,
                                      width: 36,
                                      height: 36)
@@ -176,12 +172,12 @@ extension SinglePostView {
     
     @ViewBuilder
     var singleImageView: some View {
-        CustomAsyncImage(url: postImageURLs.first ?? "", 
+        CustomAsyncImage(url: postImageURLs.first ?? "",
                          type: .postImage,
                          width: 314,
                          height: 200) { image in
                             self.loadedImage.append((0, image))
-                         }
+                        }
             .onTapGesture {
                 if postType == .DetailView {
                     isDetailImage.toggle()
@@ -203,7 +199,7 @@ extension SinglePostView {
                                      width: 206,
                                      height: 200) { image in
                                         self.loadedImage.append((index, image))
-                                     }
+                                    }
                         .onTapGesture {
                             if postType == .DetailView {
                                 isDetailImage.toggle()

--- a/Treehouse/Treehouse/Presentation/Profile/Views/MemberProfileView.swift
+++ b/Treehouse/Treehouse/Presentation/Profile/Views/MemberProfileView.swift
@@ -15,7 +15,7 @@ struct MemberProfileView: View {
     
     @State var memberProfileViewModel: MemberProfileViewModel
     @State var emojiViewModel: EmojiViewModel = EmojiViewModel(createReactionToPostUseCase: CreateReactionToPostUseCase(repository: FeedRepositoryImpl()))
-    @State var postViewModel = PostViewModel(readFeedPostUseCase: ReadFeedPostUseCase(repository: FeedRepositoryImpl()), createFeedPostsUseCase: CreateFeedPostsUseCase(repository: FeedRepositoryImpl()))
+    @State var postViewModel = PostViewModel(readFeedPostUseCase: ReadFeedPostUseCase(repository: FeedRepositoryImpl()), createFeedPostsUseCase: CreateFeedPostsUseCase(repository: FeedRepositoryImpl()), readPageFeedPostUseCase: ReadPageFeedPostUseCase(repository: FeedRepositoryImpl()))
     
     @State var isPresent = false
     @State var isLoading = true

--- a/Treehouse/Treehouse/ViewRouter/ViewRouter.swift
+++ b/Treehouse/Treehouse/ViewRouter/ViewRouter.swift
@@ -30,7 +30,13 @@ final class ViewRouter: RouterAction {
     
     private(set) var currentView: ViewType = .userAuthentication
     
-    var selectedTab: TabType = .home
+    var selectedTab: TabType = .home {
+        didSet {
+            isSameTap = oldValue == selectedTab ? true : false
+        }
+    }
+    
+    var isSameTap: Bool = false
     
     var path = NavigationPath() {
         didSet {


### PR DESCRIPTION
## 📟 관련 이슈
- Resolved: #105 

## 👷 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
- Feed 데이터 pagination 로직 구현
- 이미지를 로드하는 ImageLoader 구현 ( URLCache 사용 )
- TabView 에서 현재 Tab 을 다시 한번 누를 시 ScrollView(FeedView) 최상단으로 이동 
- Image resize 비율 재조정 ( 3MB 이하로 )

<br>

## 🚨 참고 사항
### ` ImageLoader ` 를 통해 Image 로드 및 URLCache 사용

``` swift
@Observable
final class ImageLoader {
    var image: UIImage?
    private var url: String?
        init(url: String?) {
        self.url = url
    }
    
    @MainActor
    func fetch() async {
        guard let url = url, let fetchURL = URL(string: url) else {
            state = .failure
            return
        }
        
        let request = URLRequest(url: fetchURL, cachePolicy: .returnCacheDataElseLoad)
        let usage = ImageLoader.getCurrentCacheUsage()
        
        do {
            let (data, _) = try await URLSession.shared.data(for: request)
            if let image = UIImage(data: data) {
                state = .success(image)
            } else {
                state = .failure
            }
        } catch {
            print("Error loading image: \(error)")
            state = .failure
        }
    }
}
```

기존에 사용하던 `CustomAsyncImage` 의 경우 ForEach 와 LazyVStack 으로 인해 다시 로드가 되는 상황이 발생합니다.
즉, 사용자가 스크롤을 하면 계속 네트워크 요청을 하게 되는 것입니다. 

이미 로드한 이미지를 다시 요청해서 받아오는 것은 비효율적이기 때문에 Cache 를 사용하고자 `URLRequest` 를 만들 때  `cachePolicy` 를 `returnCacheDataElseLoad` 로 설정하여 동일한 요청이 있을 시에는 네트워크 요청을 하지 않고 Cache 에서 반환하도록 합니다. 

<br>

### ` configureURLCache `  로 캐쉬 용량 설정하기

``` swift
private func configureURLCache() {
        let totalMemory = ProcessInfo.processInfo.physicalMemory
        let deviceAdjustedLimit = Int(Double(totalMemory) * 0.03) // 디바이스의 램 용량 중 0.03 퍼센트만 사용 ( 최대 cache 용량 설정)
        
        let memoryCapacity = 150 * 1024 * 1024 // 150 MB
        let diskCapacity = 100 * 1024 * 1024 // 100 MB
        
        let cacheLimit = min(memoryCapacity, deviceAdjustedLimit)
        
        let cache = URLCache(memoryCapacity: cacheLimit, diskCapacity: diskCapacity, diskPath: "myImages")
        URLCache.shared = cache
    }

func applicationWillTerminate(_ application: UIApplication) {
    URLCache.shared.removeAllCachedResponses()
}
```

기기의 총 메모리 중 일부를 캐시 용도로 사용하기 위해선 사용할 용량을 설정해주어야 합니다. 
주로 캐쉬 용량을 설정할 때는 메모리, 디스크 캐쉬를 설정하며 시스템이 우선적으로 메모리 캐쉬에 데이터를 저장하지만 이미지 경우 디스크 캐쉬에 주로 저장되고 작은 크기의 데이터는 메모리 캐쉬에 저장된다고 합니다.

메모리 캐쉬는 RAM 에 저장되고 앱 종료시 데이터는 손실되지만 디스크 캐쉬는 디스크(내부 저장) 에 저장되며 앱이 종료되어도 손실되지 않습니다.
이러한 특징으로 인해 앱이 종료 될때는 부여한 Cache 공간을 제거할 수 있도록 하였습니다.

<br>

## 📸 스크린샷

- Cache 를 쓰지 않았을 때

https://github.com/user-attachments/assets/4058b2a2-7042-4b82-acfa-f9f0c7ae4983

- Cache 를 썼을 때

https://github.com/user-attachments/assets/3056f2c1-a1a3-4c4b-a61a-16f0e362f3cd

<br>

## 📂 참고한 내용

https://www.youtube.com/watch?v=CQDiQF-1_rY

<br>

## ✅ Checklist
- [X] 필요없는 주석, 프린트문 제거했는지 확인
- [X] 컨벤션 지켰는지 확인
