### PR TITLE
[Fix] #112 - 댓글 달기 버튼 위치 수정 및 이모지 선택 시 API 호출 로직 수정

### DIFF
--- a/Treehouse/Treehouse/Presentation/Feed/FeedContentScene/Views/ColorEmojiPopover.swift
+++ b/Treehouse/Treehouse/Presentation/Feed/FeedContentScene/Views/ColorEmojiPopover.swift
@@ -11,14 +11,42 @@ struct ColorEmojiPopover: View {
     
     // MARK: - Property
     
+    @Environment (FeedViewModel.self) var feedViewModel
+    @Environment (EmojiViewModel.self) var emojiViewModel
+    
     let selectEmoji: EmojiDatas
+    var emojiType: EmojiListType
+    
+    var commentId: Int?
+    var postId: Int?
+    
+    @Binding var isPresented: Bool
+    
+    init(selectEmoji: EmojiDatas, emojiType: EmojiListType, postId: Int, isPresented: Binding<Bool>) {
+        self.selectEmoji = selectEmoji
+        self.emojiType = emojiType
+        commentId = nil
+        self.postId = postId
+        self._isPresented = isPresented
+    }
+    
+    init(selectEmoji: EmojiDatas, emojiType: EmojiListType, commentId: Int, isPresented: Binding<Bool>) {
+        self.selectEmoji = selectEmoji
+        self.emojiType = emojiType
+        self.commentId = commentId
+        postId = nil
+        self._isPresented = isPresented
+    }
     
     // MARK: - View
     
     var body: some View {
         HStack(spacing: 10) {
             Button(action: {
-
+                isPresented.toggle()
+                Task {
+                    await emojiTappedAction()
+                }
             }) {
                 Text(selectEmoji.unicodeEmoji)
             }
@@ -27,7 +55,11 @@ struct ColorEmojiPopover: View {
             
             ForEach(selectEmoji.color) { emojiData in
                 Button(action: {
-
+                    isPresented.toggle()
+                    Task {
+                        emojiViewModel.selectEmoji = emojiData.unicodeEmoji
+                        await emojiTappedAction()
+                    }
                 }) {
                     Text(emojiData.unicodeEmoji)
                 }
@@ -36,16 +68,43 @@ struct ColorEmojiPopover: View {
         .font(.system(size: 30))
         .padding(EdgeInsets(top: 10, leading: 15, bottom: 10, trailing: 15))
     }
+    
+    func emojiTappedAction() async {
+        Task {
+            switch emojiType {
+            case .feedView:
+                let result = await emojiViewModel.createReactionPost(
+                    treehouseId: feedViewModel.currentTreehouseId ?? 0,
+                    postId: postId ?? 0
+                )
+                
+            case .detailView:
+                let result = await emojiViewModel.createReactionComment(
+                    treehouseId: feedViewModel.currentTreehouseId ?? 0,
+                    postId: feedViewModel.currentPostId ?? 0,
+                    commentId: feedViewModel.currentCommentId ?? 0
+                )
+            }
+            
+            switch emojiType {
+            case .feedView:
+                feedViewModel.isSelectEmojiView = false
+                emojiViewModel.isSelectFeedEmojiView = false
+            case .detailView:
+                emojiViewModel.isSelectCommentEmojiView = false
+            }
+        }
+    }
 }
 
 // MARK: - Preview
 
-#Preview {
-    ColorEmojiPopover(selectEmoji: EmojiDatas(unicode: "U+1F590",
-                                              description: "hand with fingers splayed",
-                                              descriptionKorea: "손가락을 벌린 손",
-                                              color: [EmojiColorDatas(unicode: "U+1F590 U+1F3FB", 
-                                                                      description: "hand with fingers splayed: light skin tone",
-                                                                      descriptionKorea: "손가락을 벌린 손: 밝은 피부톤")]
-                                             ))
-}
+//#Preview {
+//    ColorEmojiPopover(selectEmoji: EmojiDatas(unicode: "U+1F590",
+//                                              description: "hand with fingers splayed",
+//                                              descriptionKorea: "손가락을 벌린 손",
+//                                              color: [EmojiColorDatas(unicode: "U+1F590 U+1F3FB", 
+//                                                                      description: "hand with fingers splayed: light skin tone",
+//                                                                      descriptionKorea: "손가락을 벌린 손: 밝은 피부톤")]
+//                                             ))
+//}

--- a/Treehouse/Treehouse/Presentation/Feed/FeedContentScene/Views/CommentView.swift
+++ b/Treehouse/Treehouse/Presentation/Feed/FeedContentScene/Views/CommentView.swift
@@ -24,12 +24,16 @@ struct CommentView: View {
     
     // MARK: - Property
     
+    let commentType: CommentType
     let commentId: Int
     var replyIndex: Int? = nil
     let userProfile: MemberProfileEntity
     let time: String
     let comment: String
     var reactionData: ReactionListDataEntity
+    var focusedField: FocusState<FeedField?>.Binding
+    var isReplayList: Bool
+    var lastData: Bool?
     
     // MARK: - View
     
@@ -43,7 +47,7 @@ struct CommentView: View {
                 .padding(.trailing, 10)
 //                .padding(.trailing, commentyType == .comment ? 8 : 10)
             
-            VStack(spacing: 10) {
+            VStack(alignment: .leading, spacing: 10) {
                 VStack(alignment: .leading, spacing: 1) {
                     HStack(alignment: .center) {
                         Text(userProfile.memberName)
@@ -84,9 +88,29 @@ struct CommentView: View {
                 DetailEmojiListView(emojiType: .commentView, postId: feedViewModel.currentPostId ?? 0, commentId: commentId, emojiData: reactionData)
                     .environment(commentViewModel)
                     
-//                    .onAppear {
-//                        emojiViewModel.detailEmojiData = reactionData.reactionList
-//                    }
+                if isReplayList == false && commentType == .comment {
+                    Button(action: {
+                        feedViewModel.currentCommentId = commentId
+                        focusedField.wrappedValue = .post
+                        commentViewModel.createCommentMemberName = userProfile.memberName
+                        commentViewModel.commentState = .createReplyComment
+                    }) {
+                        Text("답글 달기")
+                            .fontWithLineHeight(fontLevel: .body4)
+                            .foregroundStyle(.treeGreen)
+                    }
+                } else if isReplayList == true && commentType == .reply && lastData == true {
+                    Button(action: {
+                        feedViewModel.currentCommentId = commentId
+                        focusedField.wrappedValue = .post
+                        commentViewModel.createCommentMemberName = userProfile.memberName
+                        commentViewModel.commentState = .createReplyComment
+                    }) {
+                        Text("답글 달기")
+                            .fontWithLineHeight(fontLevel: .body4)
+                            .foregroundStyle(.treeGreen)
+                    }
+                }
             }
         }
         .onAppear {

--- a/Treehouse/Treehouse/Presentation/Feed/FeedContentScene/Views/EmojiGridView.swift
+++ b/Treehouse/Treehouse/Presentation/Feed/FeedContentScene/Views/EmojiGridView.swift
@@ -50,6 +50,8 @@ struct EmojiGridView: View {
     // MARK: - View
 
     var body: some View {
+        @Bindable var emojiViewModel = emojiViewModel
+        
         VStack(spacing: 0) {
             VStack(spacing: 0) {
                 RoundedRectangle(cornerRadius: 2.5)
@@ -89,8 +91,10 @@ struct EmojiGridView: View {
                                         self.selectedId = data.id
                                         emojiViewModel.selectEmoji = data.unicodeEmoji
                                         
-                                        Task {
-                                            await emojiTappedAction()
+                                        if data.color.isEmpty {
+                                            Task {
+                                                await emojiTappedAction()
+                                            }
                                         }
                                     }
                                 }) {
@@ -99,9 +103,15 @@ struct EmojiGridView: View {
                                 }
                                 .disabled(selectedId != nil && selectedId != data.id)
                                 .popover(isPresented: self.makeIsPresented(item: data), attachmentAnchor: .point(.center)) {
-                                    ColorEmojiPopover(selectEmoji: data)
-                                        .font(.system(size: 30))
-                                        .presentationCompactAdaptation(.popover)
+                                    if emojiType == .feedView {
+                                        ColorEmojiPopover(selectEmoji: data, emojiType: emojiType, postId: postId ?? 0, isPresented: self.makeIsPresented(item: data))
+                                            .font(.system(size: 30))
+                                            .presentationCompactAdaptation(.popover)
+                                    } else {
+                                        ColorEmojiPopover(selectEmoji: data, emojiType: emojiType, commentId: commentId ?? 0, isPresented: self.makeIsPresented(item: data))
+                                            .font(.system(size: 30))
+                                            .presentationCompactAdaptation(.popover)
+                                    }
                                 }
                             }
                         }
@@ -153,13 +163,13 @@ extension EmojiGridView {
         Task {
             switch emojiType {
             case .feedView:
-                let result = await emojiViewModel.createReactionPost(
+                _ = await emojiViewModel.createReactionPost(
                     treehouseId: feedViewModel.currentTreehouseId ?? 0,
                     postId: postId ?? 0
                 )
                 
             case .detailView:
-                let result = await emojiViewModel.createReactionComment(
+                _ = await emojiViewModel.createReactionComment(
                     treehouseId: feedViewModel.currentTreehouseId ?? 0,
                     postId: feedViewModel.currentPostId ?? 0,
                     commentId: feedViewModel.currentCommentId ?? 0

--- a/Treehouse/Treehouse/Presentation/Feed/FeedContentScene/Views/FeedContentView.swift
+++ b/Treehouse/Treehouse/Presentation/Feed/FeedContentScene/Views/FeedContentView.swift
@@ -16,8 +16,6 @@ struct FeedContentView: View {
     @Environment (EmojiViewModel.self) var emojiViewModel
     var focusedField: FocusState<FeedField?>.Binding
 
-//    @State var emojiViewModel: EmojiViewModel = EmojiViewModel(createReactionToCommentUseCase: CreateReactionToCommentUseCase(repository: CommentRepositoryImpl()))
-
     // MARK: - View
     
     var body: some View {
@@ -25,28 +23,18 @@ struct FeedContentView: View {
         
         LazyVStack(alignment: .leading, spacing: 0) {
             ForEach(commentViewModel.unwrappedReadCommentData) { comment in
-                CommentView(commentId: comment.commentId,
+                CommentView(commentType: .comment,
+                            commentId: comment.commentId,
                             userProfile: comment.memberProfile,
                             time: comment.commentedAt,
                             comment: comment.context,
-                            reactionData: comment.reactionList)
+                            reactionData: comment.reactionList,
+                            focusedField: focusedField,
+                            isReplayList: !comment.replyList.isEmpty)
                     .padding(EdgeInsets(top: 10, leading: 16, bottom: 10, trailing: 16))
-//                    .environment(emojiViewModel)
                 
                 replyView(reply: comment.replyList)
                     .padding(EdgeInsets(top: 10, leading: 60, bottom: 10, trailing: 16))
-                
-                Button(action: {
-                    feedViewModel.currentCommentId = comment.commentId
-                    focusedField.wrappedValue = .post
-                    commentViewModel.createCommentMemberName = comment.memberProfile.memberName
-                    commentViewModel.commentState = .createReplyComment
-                }) {
-                    Text("답글 달기")
-                        .fontWithLineHeight(fontLevel: .body4)
-                        .foregroundStyle(.treeGreen)
-                }
-                .padding(.leading, 60)
             }
         }
         .onAppear {
@@ -62,11 +50,15 @@ private extension FeedContentView {
     func replyView(reply: [ReplyListEntity]?) -> some View {
         if let data = reply {
             ForEach(data) {
-                CommentView(commentId: $0.commentId,
+                CommentView(commentType: .reply,
+                            commentId: $0.commentId,
                             userProfile: $0.memberProfile,
                             time: $0.commentedAt,
                             comment: $0.context,
-                            reactionData: $0.reactionList)
+                            reactionData: $0.reactionList, 
+                            focusedField: focusedField,
+                            isReplayList: true,
+                            lastData: $0.commentId == data.last?.commentId)
                 .environment(emojiViewModel)
             }
         }

--- a/Treehouse/Treehouse/Presentation/Feed/FeedScene/ViewModels/PostDetailViewModel.swift
+++ b/Treehouse/Treehouse/Presentation/Feed/FeedScene/ViewModels/PostDetailViewModel.swift
@@ -33,9 +33,8 @@ final class PostDetailViewModel: BaseViewModel {
         print("Deinit PostDetailViewModel")
     }
     
-    func changeEmojiData(postId: Int, selectEmoji: String) {
+    func changeEmojiData(postId: Int, selectEmoji: String) async {
         if let index = detailFeedListData?.reactionList.reactionList.firstIndex(where: { $0.reactionName == selectEmoji }) {
-            //                if feedListData[postIndex].feedEmojiData?.reactionList[index].isPushed == false {
             if detailFeedListData?.reactionList.reactionList[index].isPushed == false {
                 detailFeedListData?.reactionList.reactionList[index].isPushed = true
                 detailFeedListData?.reactionList.reactionList[index].reactionCount += 1

--- a/Treehouse/Treehouse/Presentation/Feed/FeedScene/Views/PostDetailView.swift
+++ b/Treehouse/Treehouse/Presentation/Feed/FeedScene/Views/PostDetailView.swift
@@ -150,6 +150,20 @@ struct PostDetailView: View {
                 commentViewModel.createCommentMemberName = postDetailViewModel.detailFeedListData?.memberProfile.memberName ?? ""
             }
         }
+        .onChange(of: emojiViewModel.isSelectFeedEmojiView) { _, newValue in
+            if newValue == false {
+                Task {
+                    await performAsyncTasks()
+                }
+            }
+        }
+        .onChange(of: emojiViewModel.isSelectCommentEmojiView) { _, newValue in
+            if newValue == false {
+                Task {
+                    await performAsyncTasks()
+                }
+            }
+        }
     }
     
     func performAsyncTasks() async {


### PR DESCRIPTION
## 📟 관련 이슈
- Resolved: #112 

## 👷 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
- DetailView 에서 이모지 선택 시 글을 다시 로드하는 로직 추가
- ColorEmojiPopover 에서 색상 이모지 선택 시 Popover 가 닫히고 EmojiGridView 가 내려가는 로직 추가
- 답글 달기 버튼을 댓글 제일 하단에 존재하도록 위치 수정

<br>

## 📸 스크린샷

### 이전 영상

https://github.com/user-attachments/assets/9e234fcc-77ab-4db7-a845-e17f5a36b854

### 수정 후 영상

https://github.com/user-attachments/assets/879eba89-2651-4ede-bcdc-4681a4d24a3b

<br>

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
