### PR TITLE
[Feat] #115 - FirebaseAuth 전화인증 로직 구현

### DIFF
--- a/Treehouse/Treehouse.xcodeproj/project.pbxproj
+++ b/Treehouse/Treehouse.xcodeproj/project.pbxproj
@@ -91,10 +91,6 @@
 		3F2DB2792BCFF5FE00DEFBA6 /* ReceivedInvitationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F2DB2782BCFF5FE00DEFBA6 /* ReceivedInvitationView.swift */; };
 		3F2DB27B2BD0C83900DEFBA6 /* InvitationAlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F2DB27A2BD0C83900DEFBA6 /* InvitationAlertView.swift */; };
 		3F2DB27D2BD0F35900DEFBA6 /* InvitationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F2DB27C2BD0F35900DEFBA6 /* InvitationView.swift */; };
-		3F32C0472C635DDB00705708 /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = 3F32C0462C635DDB00705708 /* FirebaseAnalytics */; };
-		3F32C0492C635DDB00705708 /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 3F32C0482C635DDB00705708 /* FirebaseAuth */; };
-		3F32C04B2C635DDB00705708 /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 3F32C04A2C635DDB00705708 /* FirebaseMessaging */; };
-		3F32C04D2C6362FA00705708 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3F32C04C2C6362FA00705708 /* GoogleService-Info.plist */; };
 		3F32DAC22C5B89EF001786BC /* CreateTreehouseRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F32DAC12C5B89EF001786BC /* CreateTreehouseRouter.swift */; };
 		3F3DAE982C57D09800C1424C /* ReportCommentUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F3DAE972C57D09800C1424C /* ReportCommentUseCase.swift */; };
 		3F3DAE9B2C588CE900C1424C /* TreehouseViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F3DAE9A2C588CE900C1424C /* TreehouseViewModel.swift */; };
@@ -176,6 +172,10 @@
 		3F94635D2C11644600229940 /* CheckUserPhoneUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F94635C2C11644600229940 /* CheckUserPhoneUseCase.swift */; };
 		3F94635F2C11650600229940 /* CheckUserPhoneResponseEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F94635E2C11650600229940 /* CheckUserPhoneResponseEntity.swift */; };
 		3F9463612C11662200229940 /* PostCheckUserPhoneResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F9463602C11662200229940 /* PostCheckUserPhoneResponseDTO.swift */; };
+		3FA085BF2C773991001D3E90 /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = 3FA085BE2C773991001D3E90 /* FirebaseAnalytics */; };
+		3FA085C12C773991001D3E90 /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 3FA085C02C773991001D3E90 /* FirebaseAuth */; };
+		3FA085C32C773991001D3E90 /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 3FA085C22C773991001D3E90 /* FirebaseMessaging */; };
+		3FA085C72C782877001D3E90 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3FA085C62C782877001D3E90 /* GoogleService-Info.plist */; };
 		3FA175D42C1ABDB900A57987 /* PostPresignedURLRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FA175D32C1ABDB900A57987 /* PostPresignedURLRequestDTO.swift */; };
 		3FA175D62C1ABDED00A57987 /* PostPresignedURLResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FA175D52C1ABDED00A57987 /* PostPresignedURLResponseDTO.swift */; };
 		3FA175D92C1AC2A200A57987 /* UIImage+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FA175D82C1AC2A200A57987 /* UIImage+.swift */; };
@@ -383,7 +383,6 @@
 		3F2DB2782BCFF5FE00DEFBA6 /* ReceivedInvitationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceivedInvitationView.swift; sourceTree = "<group>"; };
 		3F2DB27A2BD0C83900DEFBA6 /* InvitationAlertView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvitationAlertView.swift; sourceTree = "<group>"; };
 		3F2DB27C2BD0F35900DEFBA6 /* InvitationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvitationView.swift; sourceTree = "<group>"; };
-		3F32C04C2C6362FA00705708 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		3F32DAC12C5B89EF001786BC /* CreateTreehouseRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateTreehouseRouter.swift; sourceTree = "<group>"; };
 		3F3DAE972C57D09800C1424C /* ReportCommentUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportCommentUseCase.swift; sourceTree = "<group>"; };
 		3F3DAE9A2C588CE900C1424C /* TreehouseViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TreehouseViewModel.swift; sourceTree = "<group>"; };
@@ -464,6 +463,7 @@
 		3F94635C2C11644600229940 /* CheckUserPhoneUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckUserPhoneUseCase.swift; sourceTree = "<group>"; };
 		3F94635E2C11650600229940 /* CheckUserPhoneResponseEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckUserPhoneResponseEntity.swift; sourceTree = "<group>"; };
 		3F9463602C11662200229940 /* PostCheckUserPhoneResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCheckUserPhoneResponseDTO.swift; sourceTree = "<group>"; };
+		3FA085C62C782877001D3E90 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		3FA175D32C1ABDB900A57987 /* PostPresignedURLRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostPresignedURLRequestDTO.swift; sourceTree = "<group>"; };
 		3FA175D52C1ABDED00A57987 /* PostPresignedURLResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostPresignedURLResponseDTO.swift; sourceTree = "<group>"; };
 		3FA175D82C1AC2A200A57987 /* UIImage+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+.swift"; sourceTree = "<group>"; };
@@ -600,7 +600,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3F32C04B2C635DDB00705708 /* FirebaseMessaging in Frameworks */,
+				3FA085C32C773991001D3E90 /* FirebaseMessaging in Frameworks */,
 				00CF35BB2BC306D500D9E332 /* SVGKitSwift in Frameworks */,
 				00CF35AC2BC2F4C900D9E332 /* Kingfisher in Frameworks */,
 				00CF35B92BC306D500D9E332 /* SVGKit in Frameworks */,
@@ -608,9 +608,9 @@
 				00CF35A92BC2F48800D9E332 /* Lottie in Frameworks */,
 				00CF35A22BC2F42F00D9E332 /* Moya in Frameworks */,
 				00CF35A02BC2F42F00D9E332 /* CombineMoya in Frameworks */,
-				3F32C0492C635DDB00705708 /* FirebaseAuth in Frameworks */,
+				3FA085C12C773991001D3E90 /* FirebaseAuth in Frameworks */,
 				00CF35A62BC2F42F00D9E332 /* RxMoya in Frameworks */,
-				3F32C0472C635DDB00705708 /* FirebaseAnalytics in Frameworks */,
+				3FA085BF2C773991001D3E90 /* FirebaseAnalytics in Frameworks */,
 				00CF35A42BC2F42F00D9E332 /* ReactiveMoya in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -918,7 +918,7 @@
 				00CF35852BC291FC00D9E332 /* Assets.xcassets */,
 				3FF1072A2BEA0BE700C52908 /* Config.swift */,
 				00F592432BF5F4F700BF6AED /* Config.xcconfig */,
-				3F32C04C2C6362FA00705708 /* GoogleService-Info.plist */,
+				3FA085C62C782877001D3E90 /* GoogleService-Info.plist */,
 			);
 			path = Resources;
 			sourceTree = "<group>";
@@ -1841,9 +1841,9 @@
 				00CF35B82BC306D500D9E332 /* SVGKit */,
 				00CF35BA2BC306D500D9E332 /* SVGKitSwift */,
 				9475A6132C1A5AEF00333A72 /* PopupView */,
-				3F32C0462C635DDB00705708 /* FirebaseAnalytics */,
-				3F32C0482C635DDB00705708 /* FirebaseAuth */,
-				3F32C04A2C635DDB00705708 /* FirebaseMessaging */,
+				3FA085BE2C773991001D3E90 /* FirebaseAnalytics */,
+				3FA085C02C773991001D3E90 /* FirebaseAuth */,
+				3FA085C22C773991001D3E90 /* FirebaseMessaging */,
 			);
 			productName = Treehouse;
 			productReference = 00CF357E2BC291FA00D9E332 /* Treehouse.app */;
@@ -1879,7 +1879,7 @@
 				00CF35AA2BC2F4C900D9E332 /* XCRemoteSwiftPackageReference "Kingfisher" */,
 				00CF35B72BC306D500D9E332 /* XCRemoteSwiftPackageReference "SVGKit" */,
 				9475A6122C1A5AEF00333A72 /* XCRemoteSwiftPackageReference "PopupView" */,
-				3F32C0452C635DDB00705708 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
+				3FA085BD2C773991001D3E90 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 			);
 			productRefGroup = 00CF357F2BC291FA00D9E332 /* Products */;
 			projectDirPath = "";
@@ -1902,7 +1902,7 @@
 				00CF35862BC291FC00D9E332 /* Assets.xcassets in Resources */,
 				00F592442BF5F4F700BF6AED /* Config.xcconfig in Resources */,
 				00CF35B12BC2F63E00D9E332 /* Pretendard-SemiBold.otf in Resources */,
-				3F32C04D2C6362FA00705708 /* GoogleService-Info.plist in Resources */,
+				3FA085C72C782877001D3E90 /* GoogleService-Info.plist in Resources */,
 				3F8F2A812C18AB1400D8CB9F /* structuredEmojis.json in Resources */,
 				3FA541572C60F12100723BAD /* treehouse_loading.json in Resources */,
 			);
@@ -2455,12 +2455,12 @@
 				minimumVersion = 3.0.0;
 			};
 		};
-		3F32C0452C635DDB00705708 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
+		3FA085BD2C773991001D3E90 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/firebase/firebase-ios-sdk";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 11.0.0;
+				minimumVersion = 11.1.0;
 			};
 		};
 		9475A6122C1A5AEF00333A72 /* XCRemoteSwiftPackageReference "PopupView" */ = {
@@ -2514,19 +2514,19 @@
 			package = 00CF35B72BC306D500D9E332 /* XCRemoteSwiftPackageReference "SVGKit" */;
 			productName = SVGKitSwift;
 		};
-		3F32C0462C635DDB00705708 /* FirebaseAnalytics */ = {
+		3FA085BE2C773991001D3E90 /* FirebaseAnalytics */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 3F32C0452C635DDB00705708 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			package = 3FA085BD2C773991001D3E90 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
 			productName = FirebaseAnalytics;
 		};
-		3F32C0482C635DDB00705708 /* FirebaseAuth */ = {
+		3FA085C02C773991001D3E90 /* FirebaseAuth */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 3F32C0452C635DDB00705708 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			package = 3FA085BD2C773991001D3E90 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
 			productName = FirebaseAuth;
 		};
-		3F32C04A2C635DDB00705708 /* FirebaseMessaging */ = {
+		3FA085C22C773991001D3E90 /* FirebaseMessaging */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 3F32C0452C635DDB00705708 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			package = 3FA085BD2C773991001D3E90 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
 			productName = FirebaseMessaging;
 		};
 		9475A6132C1A5AEF00333A72 /* PopupView */ = {

--- a/Treehouse/Treehouse.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Treehouse/Treehouse.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "ccd7c655c75cacccb91e9db4be70860a7f2926390baf55993ea07240242360a9",
+  "originHash" : "c1819d4acf12213b722da03765b218ba7d4388a3ac96ee1fac3e8e0417e46737",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/firebase/firebase-ios-sdk",
       "state" : {
-        "revision" : "a5c253d1b4409eb8aef4346015ba000f9935cb2d",
-        "version" : "11.0.0"
+        "revision" : "9118aca998dbe2ceac45d64b21a91c6376928df7",
+        "version" : "11.1.0"
       }
     },
     {
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleAppMeasurement.git",
       "state" : {
-        "revision" : "ca30c987b732d130732fb60b071e0b655a85ada7",
-        "version" : "11.0.0"
+        "revision" : "07a2f57d147d2bf368a0d2dcb5579ff082d9e44f",
+        "version" : "11.1.0"
       }
     },
     {

--- a/Treehouse/Treehouse/Application/TreehouseApp.swift
+++ b/Treehouse/Treehouse/Application/TreehouseApp.swift
@@ -7,51 +7,54 @@
 
 import SwiftUI
 import SwiftData
-import FirebaseCore
+import Firebase
 import FirebaseMessaging
+import FirebaseAuth
+import UserNotifications
 
 class AppDelegate: NSObject, UIApplicationDelegate {
     
-    let gcmMessageIDKey = "gcm.message_id"
     
     func application(_ application: UIApplication,
                      didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
-        
+
         // 파이어베이스 설정
         FirebaseApp.configure()
+        Auth.auth().languageCode = "ko"
         
-        // Setting Up Notifications...
-        // 원격 알림 등록
-        if #available(iOS 10.0, *) {
-            // For iOS 10 display notification (sent via APNS)
-            UNUserNotificationCenter.current().delegate = self
-            
-            let authOption: UNAuthorizationOptions = [.alert, .badge, .sound]
-            UNUserNotificationCenter.current().requestAuthorization(
-                options: authOption,
-                completionHandler: {_, _ in })
-        } else {
-            let settings: UIUserNotificationSettings =
-            UIUserNotificationSettings(types: [.alert, .badge, .sound], categories: nil)
-            application.registerUserNotificationSettings(settings)
-        }
-        
+        UNUserNotificationCenter.current().delegate = self
         application.registerForRemoteNotifications()
-        
-        
+
         // Setting Up Cloud Messaging...
         // 메세징 델리겟
         Messaging.messaging().delegate = self
         
-        UNUserNotificationCenter.current().delegate = self
         return true
     }
     
-    // fcm 토큰이 등록 되었을 때
+    // APNS 토큰을 Firebase에 등록
     func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+        // Firebase Messaging을 위한 설정
         Messaging.messaging().apnsToken = deviceToken
+        
+        // Firebase Auth를 위한 설정
+        Auth.auth().setAPNSToken(deviceToken, type: AuthAPNSTokenType.sandbox)
     }
-    
+
+    // 원격 알림 처리
+    func application(_ application: UIApplication, didReceiveRemoteNotification userInfo: [AnyHashable : Any],
+                     fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
+        // 다른 원격 알림 처리 로직
+        let firebaseAuth = Auth.auth()
+        if (firebaseAuth.canHandleNotification(userInfo)){
+            print(userInfo)
+            completionHandler(.noData)
+            return
+        }
+        
+        completionHandler(.newData)
+    }
+
     func applicationWillTerminate(_ application: UIApplication) {
         // 앱이 종료될 때 캐시 제거
         URLCache.shared.removeAllCachedResponses()
@@ -156,14 +159,7 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
                                 withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
         
         let userInfo = notification.request.content.userInfo
-        
-        
-        // Do Something With MSG Data...
-        if let messageID = userInfo[gcmMessageIDKey] {
-            print("Message ID: \(messageID)")
-        }
-        
-        
+
         print(userInfo)
         
         completionHandler([[.banner, .badge, .sound]])
@@ -174,11 +170,6 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
                                 didReceive response: UNNotificationResponse,
                                 withCompletionHandler completionHandler: @escaping () -> Void) {
         let userInfo = response.notification.request.content.userInfo
-        
-        // Do Something With MSG Data...
-        if let messageID = userInfo[gcmMessageIDKey] {
-            print("Message ID: \(messageID)")
-        }
         
         print(userInfo)
         

--- a/Treehouse/Treehouse/Info.plist
+++ b/Treehouse/Treehouse/Info.plist
@@ -13,10 +13,12 @@
 			<string>Editor</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>app-1-569285689763-ios-550e4798e676293af59a16</string>
+				<string>com.googleusercontent.apps.569285689763-5cpfmk9ouq64nhqcjjk5rkjapp1qtiik</string>
 			</array>
 		</dict>
 	</array>
+	<key>FirebaseAppDelegateProxyEnabled</key>
+	<false/>
 	<key>LOGIN_KEY</key>
 	<string>$(LOGIN_KEY)</string>
 	<key>REFRESH_TOKEN_KEY</key>

--- a/Treehouse/Treehouse/Info.plist
+++ b/Treehouse/Treehouse/Info.plist
@@ -6,6 +6,17 @@
 	<string>$(ACCESS_TOKEN_KEY)</string>
 	<key>BASE_URL</key>
 	<string>$(BASE_URL)</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>app-1-569285689763-ios-550e4798e676293af59a16</string>
+			</array>
+		</dict>
+	</array>
 	<key>LOGIN_KEY</key>
 	<string>$(LOGIN_KEY)</string>
 	<key>REFRESH_TOKEN_KEY</key>

--- a/Treehouse/Treehouse/Presentation/Auth/InvitationScene/Views/PhoneNumberRow.swift
+++ b/Treehouse/Treehouse/Presentation/Auth/InvitationScene/Views/PhoneNumberRow.swift
@@ -23,11 +23,11 @@ struct PhoneNumberRow: View {
             
             VStack(alignment: .leading, spacing: 2) {
                 Text(userInfo.name)
-                    .font(.fontGuide(.body2))
+                    .fontWithLineHeight(fontLevel: .body2)
                     .foregroundColor(.grayscaleBlack)
                 
                 Text(userInfo.phoneNumber)
-                    .font(.fontGuide(.body5))
+                    .fontWithLineHeight(fontLevel: .body5)
                     .foregroundColor(.gray5)
             }
             .padding(.leading, 10)

--- a/Treehouse/Treehouse/Presentation/Auth/RegisterScene/Views/SetPhoneNumberView.swift
+++ b/Treehouse/Treehouse/Presentation/Auth/RegisterScene/Views/SetPhoneNumberView.swift
@@ -47,8 +47,8 @@ struct SetPhoneNumberView: View {
                         
                         if errorMessage == errorMessage {
                             Text(errorMessage ?? "")
+                                .fontWithLineHeight(fontLevel: .caption1)
                                 .foregroundColor(.error)
-                                .font(.fontGuide(.caption1))
                         }
                     }
                     

--- a/Treehouse/Treehouse/Presentation/Auth/RegisterScene/Views/SetUserIdView.swift
+++ b/Treehouse/Treehouse/Presentation/Auth/RegisterScene/Views/SetUserIdView.swift
@@ -60,7 +60,7 @@ struct SetUserIdView: View {
                 }
             }) {
                 Text(StringLiterals.Register.buttonTitle5)
-                    .font(.fontGuide(.body2))
+                    .fontWithLineHeight(fontLevel: .body2)
                     .padding()
                     .frame(maxWidth: .infinity)
                     .frame(height: 56)

--- a/Treehouse/Treehouse/Presentation/Auth/RegisterScene/Views/UnableRegisterView.swift
+++ b/Treehouse/Treehouse/Presentation/Auth/RegisterScene/Views/UnableRegisterView.swift
@@ -51,7 +51,7 @@ struct UnableRegisterView: View {
             Spacer(minLength: SizeLiterals.Screen.screenHeight * 26 / 852)
             
             Button {
-                print("돌아가기 버튼 탭했음")
+                viewRouter.popToRoot()
             } label: {
                 Text(StringLiterals.Register.buttonTitle3)
                     .fontWithLineHeight(fontLevel: .body2)

--- a/Treehouse/Treehouse/Presentation/Auth/RegisterScene/Views/VerificationView.swift
+++ b/Treehouse/Treehouse/Presentation/Auth/RegisterScene/Views/VerificationView.swift
@@ -66,10 +66,12 @@ struct VerificationView: View {
                         Task {
                             await viewModel.checkVerificationCode()
                         }
+                    } else {
+                        viewModel.isCallCehckVerification = false
                     }
                 }
                 
-                Text(isValid == false ? "" : StringLiterals.Register.indicatorTitle2)
+                Text(viewModel.isCallCehckVerification && viewModel.isCheckVerification == false ? StringLiterals.Register.indicatorTitle2 : "")
                     .fontWithLineHeight(fontLevel: .caption1)
                     .foregroundStyle(.error)
                 
@@ -100,10 +102,17 @@ struct VerificationView: View {
                 }
             } label: {
                 Text(StringLiterals.Register.buttonTitle2)
-                    .font(.fontGuide(.body2))
+                    .fontWithLineHeight(fontLevel: .body2)
                     .frame(width: SizeLiterals.Screen.screenWidth * 344 / 393, height: 56)
-                    .disableWithOpacity(verificationCode.count < 6)
+                    .foregroundStyle(viewModel.isCheckVerification ? .gray1 : .gray6)
+                    .background(viewModel.isCheckVerification ? .treeBlack : .gray2)
                     .cornerRadius(12)
+            }
+            .disabled(!viewModel.isCheckVerification)
+            .onChange(of: viewModel.isCheckVerification) { _ , newValue in
+                if newValue {
+                    isKeyboardShowing = false
+                }
             }
         }
         .padding(.horizontal, SizeLiterals.Screen.screenWidth * 24 / 393)

--- a/Treehouse/Treehouse/Presentation/Auth/RegisterScene/Views/VerificationView.swift
+++ b/Treehouse/Treehouse/Presentation/Auth/RegisterScene/Views/VerificationView.swift
@@ -59,6 +59,15 @@ struct VerificationView: View {
                     isKeyboardShowing.toggle()
                 }
                 .padding(.bottom, 8)
+                .onChange(of: verificationCode) { _, newValue in
+                    if newValue.count == 6 {
+                        viewModel.verificationCode = verificationCode
+                        
+                        Task {
+                            await viewModel.checkVerificationCode()
+                        }
+                    }
+                }
                 
                 Text(isValid == false ? "" : StringLiterals.Register.indicatorTitle2)
                     .fontWithLineHeight(fontLevel: .caption1)
@@ -105,6 +114,9 @@ struct VerificationView: View {
         .navigationBarBackButtonHidden()
         .onAppear {
             isKeyboardShowing = true
+        }
+        .task {
+            await viewModel.certificationPhoneNumber()
         }
         .toolbar {
             ToolbarItem(placement: .topBarLeading) {

--- a/Treehouse/Treehouse/Presentation/Feed/FeedScene/Views/FeedView.swift
+++ b/Treehouse/Treehouse/Presentation/Feed/FeedScene/Views/FeedView.swift
@@ -24,6 +24,7 @@ struct FeedView: View {
     @Environment (FeedViewModel.self) var feedViewModel
     @Environment (PostViewModel.self) var postViewModel
     @Environment (EmojiViewModel.self) var emojiViewModel
+    @Environment(CurrentTreehouseInfoViewModel.self) var currentTreehouseInfoViewModel
     
     @State var commentViewModel = CommentViewModel(createCommentUseCase: CreateCommentUseCase( repository: CommentRepositoryImpl()),readCommentUseCase: ReadCommentUseCase(repository: CommentRepositoryImpl()), createReplyCommentUseCase: CreateReplyCommentUseCase(repository: CommentRepositoryImpl()))
     
@@ -114,7 +115,7 @@ extension FeedView {
     private var postTextField: some View {
         VStack(spacing: 0) {
             HStack() {
-                TextField("\(feedViewModel.treehouseName)에 글쓰기...", text: $postContent, axis: .vertical)
+                TextField("\(currentTreehouseInfoViewModel.treehouseName)에 글쓰기...", text: $postContent, axis: .vertical)
                     .padding(EdgeInsets(top: 12.0, leading: 14.0, bottom: 12.0, trailing: 14.0))
                     .fontWithLineHeight(fontLevel: .body5)
                     .tint(.treeGreen)

--- a/Treehouse/Treehouse/Presentation/Feed/FeedScene/Views/PostAlertView.swift
+++ b/Treehouse/Treehouse/Presentation/Feed/FeedScene/Views/PostAlertView.swift
@@ -27,14 +27,14 @@ struct PostAlertView: View {
             
             VStack(spacing: 41) {
                 Text(alertContent)
-                    .font(.fontGuide(.heading4))
+                    .fontWithLineHeight(fontLevel: .heading4)
                 
                 HStack(spacing: 12) {
                     Button(action: {
                         onCancel()
                     }) {
                         Text("취소")
-                            .font(.fontGuide(.body3))
+                            .fontWithLineHeight(fontLevel: .body3)
                             .foregroundStyle(.treeBlack)
                             .padding(EdgeInsets(top: 11.0, leading: 64.0, bottom: 11.0, trailing: 64.0))
                             .background(.grayscaleWhite)
@@ -49,7 +49,7 @@ struct PostAlertView: View {
                         onConfirm()
                     }) {
                         Text("확인")
-                            .font(.fontGuide(.body3))
+                            .fontWithLineHeight(fontLevel: .body3)
                             .foregroundStyle(.grayscaleWhite)
                             .padding(EdgeInsets(top: 11.0, leading: 64.0, bottom: 11.0, trailing: 64.0))
                             .background(.grayscaleBlack)

--- a/Treehouse/Treehouse/Presentation/Profile/Views/EditProfileView.swift
+++ b/Treehouse/Treehouse/Presentation/Profile/Views/EditProfileView.swift
@@ -185,7 +185,7 @@ struct EditProfileView: View {
                 isEditing = true
             }) {
                 Text(isEditing ? "저장하기" : "수정하기")
-                    .font(.fontGuide(.body2))
+                    .fontWithLineHeight(fontLevel: .body2)
                     .foregroundStyle(.gray1)
                     .frame(width: SizeLiterals.Screen.screenWidth * 360 / 393, height: 56)
                     .background(isEditing ? .treeGreen : .treeBlack)

--- a/Treehouse/Treehouse/Presentation/Profile/Views/MyProfileView.swift
+++ b/Treehouse/Treehouse/Presentation/Profile/Views/MyProfileView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import PopupView
+import FirebaseAuth
 
 struct MyProfileView: View {
     
@@ -89,12 +90,20 @@ struct MyProfileView: View {
                      onCancel: { myProfileViewModel.isAlert.0.toggle() },
                      onConfirm: { switch myProfileViewModel.isAlert.1 {
                      case .logout:
-                         
-                         self.isLogin.toggle()
                          userInfoViewModel.deleteMyData()
                          
-                         DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+                         do {
+                             try Auth.auth().signOut()
+                             print("User signed out successfully")
+                             // 필요한 경우, 앱 내에서 상태 초기화나 화면 전환 등을 처리
+                         } catch let signOutError as NSError {
+                             print("Error signing out: %@", signOutError)
+                         }
+                         
+                         DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
                              viewRouter.navigate(viewType: .userAuthentication)
+                             viewRouter.selectedTab = .home
+                             self.isLogin.toggle()
                          }
                      case .deleteAccount:
                          break


### PR DESCRIPTION
## 📟 관련 이슈
- Resolved: #115

<Br>

## 👷 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
- FirebaseAuth 를 통해 전화번호로 인증하는 로직 구현
- 인증 코드를 입력 시 올바른지 여부 판단 후 키보드 내리는 로직 추가
- Font 관련 UI 수정

<Br>

## 🚨 참고 사항
<!-- 참고 사항을 적어주세요. 없으면 지워주세요. -->

### `AppDelegate`

``` swift
func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
        // Firebase Messaging을 위한 설정
        Messaging.messaging().apnsToken = deviceToken

        // Firebase Auth를 위한 설정
        Auth.auth().setAPNSToken(deviceToken, type: AuthAPNSTokenType.sandbox)
    }
```
다음과 같이 Push Notification 을 위해 APNs Token 을 저장하고 전화번호 인증을 위한 APNs Token 도 저장 해주어야 합니다.
현재 개발중에 있기 때문에 `.sandbox` 로 되어 있지만 배포용에서는 `.prod` 로 변경해야합니다.

### `UserSettingViewModel`

``` swift
func certificationPhoneNumber() async {
        guard let phoneNumber = phoneNumber else { return }

        let fixPhoneNumber = "+82" + phoneNumber.dropFirst(1)

        do {
            self.verificationID = try await PhoneAuthProvider.provider().verifyPhoneNumber(fixPhoneNumber, uiDelegate: nil)


            // 서버 통신 성공, verificationID를 저장
            if let verificationID = verificationID {
                UserDefaults.standard.set(verificationID, forKey: "authVerificationID")
            }

            await MainActor.run {
                self.isVerificationID = true
            }
        } catch let error as NSError {
            await MainActor.run {
                errorMessage = "인증 실패: \(error.localizedDescription)"
            }
        }
    }
```

사용자가 전화번호를 입력하면 Firebase는 이 번호로 인증 코드를 전송합니다.
Firebase는 내부적으로 인증 요청을 식별하기 위해 `verificationID` 라는 고유한 토큰을 생성합니다.

<br>

``` swift
func checkVerificationCode() async {
        guard let verificationCode = verificationCode else { return }

        guard let verificationID = UserDefaults.standard.string(forKey: "authVerificationID") else {
                print("No verification ID found.")
                return
            }

        let credential = PhoneAuthProvider.provider().credential(
            withVerificationID: verificationID,
            verificationCode: verificationCode
        )

        do {
            let authResult = try await Auth.auth().signIn(with: credential)
            print("인증 성공!")

            await MainActor.run {
                self.isCallCehckVerification = true
                self.isCheckVerification = true
            }

        } catch {
            await MainActor.run {
                self.isCheckVerification = false
                self.isCallCehckVerification = true
                errorMessage = "인증 실패: \(error.localizedDescription)"
            }
        }
    }
``` 

사용자가 전화로 받은 인증 코드를 입력하면 Firebase로 전송하면서 verificationID 도 함께 포함합니다.
Firebase는 이 verificationID 와 사용자가 입력한 인증 코드를 확인해 일치하면 인증된 사용자로 간주합니다.

<Br>

## 📸 스크린샷

https://github.com/user-attachments/assets/fab38d2c-f773-4540-ae7d-2df7e81b9b59

<Br>

## ✅ Checklist
- [X] 필요없는 주석, 프린트문 제거했는지 확인
- [X] 컨벤션 지켰는지 확인
