### PR TITLE
[Fix] #119 - FirebaseAuth Token 개발용, 배포용 분기처리 코드 작성

### DIFF
--- a/Treehouse/Treehouse.xcodeproj/project.pbxproj
+++ b/Treehouse/Treehouse.xcodeproj/project.pbxproj
@@ -2363,7 +2363,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.TeamShaka.Treehouse;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -2404,7 +2404,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.TeamShaka.Treehouse;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Treehouse/Treehouse/Application/TreehouseApp.swift
+++ b/Treehouse/Treehouse/Application/TreehouseApp.swift
@@ -38,7 +38,11 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         Messaging.messaging().apnsToken = deviceToken
         
         // Firebase Auth를 위한 설정
-        Auth.auth().setAPNSToken(deviceToken, type: AuthAPNSTokenType.sandbox)
+        #if DEBUG
+            Auth.auth().setAPNSToken(deviceToken, type: AuthAPNSTokenType.sandbox)
+        #else
+            Auth.auth().setAPNSToken(deviceToken, type: AuthAPNSTokenType.prod)
+        #endif
     }
 
     // 원격 알림 처리


### PR DESCRIPTION
## 📟 관련 이슈
- Resolved: #119 

<br>

## 👷 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
- FirebaseAuth Token 저장 타입을 개발, 배포용으로 분기처리 코드 작성

<br>

## 🚨 참고 사항
<!-- 참고 사항을 적어주세요. 없으면 지워주세요. -->

### `SetAPNSToken` 

``` swift
// APNS 토큰을 Firebase에 등록
func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
    // Firebase Messaging을 위한 설정
    Messaging.messaging().apnsToken = deviceToken
        
    // Firebase Auth를 위한 설정
    #if DEBUG
        Auth.auth().setAPNSToken(deviceToken, type: AuthAPNSTokenType.sandbox)
    #else
        Auth.auth().setAPNSToken(deviceToken, type: AuthAPNSTokenType.prod)
    #endif
}
```

`Auth.auth().setAPNSToken(_:type:)` 메서드에서 `type` 파라미터는 APNS(Apple Push Notification Service) 토큰의 환경을 지정하는 중요한 역할을 합니다. 

sandbox / prod / unknown 으로 총 3가지의 열거형 타입이 존재하며 
sandbox 는 개발하거나 테스트 상황에서, prod 는 실제 앱을 출시하고 사용시에, Unknown 은 명확하지 않은 경우에 사용합니다.

다음과 같은 이유를 통해 개발, 배포용으로 코드를 분기처리 해야하기 때문에 다음과 같이 작성하였습니다.

<br>

## ✅ Checklist
- [X] 필요없는 주석, 프린트문 제거했는지 확인
- [X] 컨벤션 지켰는지 확인
