### PR TITLE
[Feat] #123 - Treehouse 변경 시 프로필 정보 업데이트 및 DetailView 에서 프로필 이미지 로직 변경

### DIFF
--- a/Treehouse/Treehouse/Global/Components/CustomAsyncImage.swift
+++ b/Treehouse/Treehouse/Global/Components/CustomAsyncImage.swift
@@ -62,10 +62,9 @@ struct CustomAsyncImage: View {
         }
         .frame(width: SizeLiterals.Screen.screenWidth * width / 393, height: SizeLiterals.Screen.screenHeight * height / 852)
         .cornerRadius(6.0)
-        .onAppear {
-            Task {
-                await imageLoader.fetch()
-            }
+        .contentShape(Rectangle())
+        .task {
+            await imageLoader.fetch()
         }
     }
     
@@ -93,5 +92,8 @@ struct CustomAsyncImage: View {
 }
 
 #Preview {
-    CustomAsyncImage(url: "", type: .treehouseImage, width: 36, height: 36)
+    CustomAsyncImage(url: "",
+                     type: .treehouseImage,
+                     width: 36,
+                     height: 36)
 }

--- a/Treehouse/Treehouse/Global/ImageLoader.swift
+++ b/Treehouse/Treehouse/Global/ImageLoader.swift
@@ -35,12 +35,12 @@ final class ImageLoader {
    }
     
     static func getCurrentCacheUsage() -> CacheUsage {
-           let cache = URLCache.shared
-           return CacheUsage(
-               memoryUsage: cache.currentMemoryUsage,
-               diskUsage: cache.currentDiskUsage
-           )
-       }
+       let cache = URLCache.shared
+       return CacheUsage(
+           memoryUsage: cache.currentMemoryUsage,
+           diskUsage: cache.currentDiskUsage
+       )
+   }
     
     init(url: String?) {
         self.url = url

--- a/Treehouse/Treehouse/Presentation/Feed/FeedScene/Views/PostDetailView.swift
+++ b/Treehouse/Treehouse/Presentation/Feed/FeedScene/Views/PostDetailView.swift
@@ -197,7 +197,7 @@ extension PostDetailView {
                 .foregroundColor(.gray3)
             
             HStack(alignment: .center, spacing: 10) {
-                CustomAsyncImage(url: userInfoViewModel.userInfo?.treehouseInfo[feedViewModel.currentTreehouseId ?? 0].profileImageUrl?.absoluteString ?? "",
+                CustomAsyncImage(url: userInfoViewModel.userInfo?.findTreehouse(id: feedViewModel.currentTreehouseId ?? 0)?.profileImageUrl?.absoluteString ?? "",
                                  type: .postMemberProfileImage,
                                  width: 36,
                                  height: 36)


### PR DESCRIPTION
## 📟 관련 이슈
- Resolved: #123 

<br>

## 👷 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
- Treehouse 변경 시 MyProfileView 에서 사진이 바뀌지 않는 현상 해결
- DetailView 에서 TextField 옆에 있는 내 프로필 사진이 잘못 로딩 및 인덱스 오류 현상 해결

<br>

## 🚨 참고 사항
<!-- 참고 사항을 적어주세요. 없으면 지워주세요. -->

### `MyProfileView`

``` swift
.onChange(of: selectedTreehouseId) { _, newValue in
    myProfileViewModel.myProfileData = nil
    Task {
        await myProfileViewModel.readMyProfileInfo(treehouseId: selectedTreehouseId)
    }
}
```

현재 CustomAsyncImage 에서 사용하는 URL 의 경우 바인딩 처리가 되어 있지 않아 URL 이 변경되더라도 redraw 를 하지 않습니다.
이미지를 사용하는 대부분의 View 에서 이미지가 변경될 필요가 없다고 생각하여 만들었던 착오였던거 같습니다.

URL 이 변경되면 다시 로드할 수 있도록 State & Binding 을 사용하였지만 CustomAsyncImage 를 사용하는 모든 부분에서 에러가 발생하는 상황이 발생하여 해당 부분은 출시 이후 리펙토링 작업에 추가하는 것이 좋다고 생각했습니다.

우회적으로 프로필의 정보가 비어있을 경우 해당 View 를 보여주지 않게 조건문으로 처리가 되어있었기 때문에 Treehouse 가 변경됐을 때 프로필 정보를 갖고 있는 변수를 nil 처리를 하여 다시 View 를 로드할 수 있도록 우회하여 문제를 해결했습니다.

<br>

## 📸 스크린샷

https://github.com/user-attachments/assets/5537da32-bcab-4a2d-9b7f-831611377326

<br>

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
