### PR TITLE
[Fix] #128 - ViewModel 을 주입하기 위한 DIContainer 구현 및 Header UI 코드 변경

### DIFF
--- a/Treehouse/Treehouse.xcodeproj/project.pbxproj
+++ b/Treehouse/Treehouse.xcodeproj/project.pbxproj
@@ -120,6 +120,7 @@
 		3F6E13C42C7B7E4900F94595 /* DeleteUserResponseEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F6E13C32C7B7E4900F94595 /* DeleteUserResponseEntity.swift */; };
 		3F6E13C62C7C7F0400F94595 /* WebViewContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F6E13C52C7C7F0400F94595 /* WebViewContainer.swift */; };
 		3F7BCF912C60FD69000939DC /* Launch Screen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3F7BCF902C60FD69000939DC /* Launch Screen.storyboard */; };
+		3F7F25EA2C8808F400863E3D /* DIContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F7F25E92C8808F400863E3D /* DIContainer.swift */; };
 		3F81715B2C43833100CEE21E /* PostExistsUserLoginResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F81715A2C43833100CEE21E /* PostExistsUserLoginResponseDTO.swift */; };
 		3F81715D2C43847A00CEE21E /* ExistsUserLoginResponseEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F81715C2C43847A00CEE21E /* ExistsUserLoginResponseEntity.swift */; };
 		3F81715F2C4384E600CEE21E /* ExistsUserLoginUserCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F81715E2C4384E600CEE21E /* ExistsUserLoginUserCase.swift */; };
@@ -421,6 +422,7 @@
 		3F6E13C32C7B7E4900F94595 /* DeleteUserResponseEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteUserResponseEntity.swift; sourceTree = "<group>"; };
 		3F6E13C52C7C7F0400F94595 /* WebViewContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewContainer.swift; sourceTree = "<group>"; };
 		3F7BCF902C60FD69000939DC /* Launch Screen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = "Launch Screen.storyboard"; sourceTree = "<group>"; };
+		3F7F25E92C8808F400863E3D /* DIContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DIContainer.swift; sourceTree = "<group>"; };
 		3F81715A2C43833100CEE21E /* PostExistsUserLoginResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostExistsUserLoginResponseDTO.swift; sourceTree = "<group>"; };
 		3F81715C2C43847A00CEE21E /* ExistsUserLoginResponseEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExistsUserLoginResponseEntity.swift; sourceTree = "<group>"; };
 		3F81715E2C4384E600CEE21E /* ExistsUserLoginUserCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExistsUserLoginUserCase.swift; sourceTree = "<group>"; };
@@ -925,6 +927,7 @@
 				00CF35912BC2DFA800D9E332 /* Resources */,
 				00CF35B22BC3060E00D9E332 /* Extension */,
 				3FEEF75D2C69B27A002CBA53 /* ImageLoader.swift */,
+				3F7F25E92C8808F400863E3D /* DIContainer.swift */,
 			);
 			path = Global;
 			sourceTree = "<group>";
@@ -2203,6 +2206,7 @@
 				3F1BE1322C211D0200D3AF1D /* AWSImageRepositoryImpl.swift in Sources */,
 				3F81719B2C46D18D00CEE21E /* EmojiViewModel.swift in Sources */,
 				00C2F5672C15B5560009C6A1 /* SettingView.swift in Sources */,
+				3F7F25EA2C8808F400863E3D /* DIContainer.swift in Sources */,
 				3FF490042C50FD0600A6DD8A /* TreehouseRepositoryProtocol.swift in Sources */,
 				00B591952C23549400F7C38C /* ChecklAvailableInvitationUseCase.swift in Sources */,
 				3FF107022BEA07FB00C52908 /* InvitationAPI.swift in Sources */,

--- a/Treehouse/Treehouse/Global/Components/TabView/TreeTabView.swift
+++ b/Treehouse/Treehouse/Global/Components/TabView/TreeTabView.swift
@@ -82,6 +82,9 @@ struct TreeTabView: View {
                 
                 currentTreehousePerformRequest()
             }
+            .navigationDestination(for: CreateTreehouseRouter.self) { router in
+                viewRouter.buildScene(inputRouter: router)
+            }
         }
     }
     

--- a/Treehouse/Treehouse/Global/DIContainer.swift
+++ b/Treehouse/Treehouse/Global/DIContainer.swift
@@ -1,0 +1,32 @@
+//
+//  DIContainer.swift
+//  Treehouse
+//
+//  Created by ParkJunHyuk on 9/4/24.
+//
+
+import Foundation
+
+final class DIContainer {
+    static let shared = DIContainer()
+        
+    private init() {}
+    
+    // ViewModel을 저장할 딕셔너리
+    private var viewModels: [String: Any] = [:] {
+        didSet {
+            print(viewModels)
+        }
+    }
+    
+    // ViewModel 반환 메서드
+    func getViewModel<T>(for key: String, createIfNeeded: () -> T) -> T {
+        if let viewModel = viewModels[key] as? T {
+            return viewModel
+        } else {
+            let viewModel = createIfNeeded()
+            viewModels[key] = viewModel
+            return viewModel
+        }
+    }
+}

--- a/Treehouse/Treehouse/Global/ViewModel/TreehouseViewModel.swift
+++ b/Treehouse/Treehouse/Global/ViewModel/TreehouseViewModel.swift
@@ -37,6 +37,8 @@ final class TreehouseViewModel: BaseViewModel {
         self.readMyTreehouseInfoUseCase = readMyTreehouseInfoUseCase
         self.readTreehouseInfoUseCase = readTreehouseInfoUseCase
         self.createTreehouseUseCase = createTreehouseUseCase
+        
+        print("init TreehouseViewModel")
     }
     
     deinit {

--- a/Treehouse/Treehouse/Presentation/Feed/FeedScene/Views/HeaderView.swift
+++ b/Treehouse/Treehouse/Presentation/Feed/FeedScene/Views/HeaderView.swift
@@ -9,19 +9,11 @@ import SwiftUI
 
 struct HeaderView: View {
     
+    // MARK: - State Property
+    
     @Environment(ViewRouter.self) var viewRouter
     @Environment(CurrentTreehouseInfoViewModel.self) var currentTreehouseInfoViewModel
     @State var treehouseViewModel = TreehouseViewModel(readMyTreehouseInfoUseCase: ReadMyTreehouseInfoUseCase(repository: TreehouseRepositoryImpl()))
-    @State var createTreehouseViewModel = CreateTreehouseViewModel(
-        checkTreehouseNameUseCase: CheckTreehouseNameUseCase(repository: TreehouseRepositoryImpl()),
-        createTreehouseUseCase: CreateTreehouseUseCase(repository: TreehouseRepositoryImpl())
-    )
-    
-    // MARK: - Property
-    
-//    var treehouseId: Int
-//    var treehouseName: String
-//    var treehouseImageUrl: String
     
     // MARK: - Binding Property
     
@@ -67,18 +59,5 @@ struct HeaderView: View {
                 .isOpaque(true)
                 .backgroundColor(.treeBlack.opacity(0.5))
         }
-        .navigationDestination(for: CreateTreehouseRouter.self) { router in
-            viewRouter.buildScene(inputRouter: router, viewModel: createTreehouseViewModel)
-        }
-//        .onChange(of: treehouseId) { _, newValue in
-//            Task {
-//                await treehouseViewModel.readTreehouseInfo(treehouseId: newValue)
-//            }
-//        }
-//        .onAppear {
-//            Task {
-//                await treehouseViewModel.readTreehouseInfo(treehouseId: treehouseId)
-//            }
-//        }
     }
 }

--- a/Treehouse/Treehouse/Presentation/Feed/FeedScene/Views/TreehouseInfoListView.swift
+++ b/Treehouse/Treehouse/Presentation/Feed/FeedScene/Views/TreehouseInfoListView.swift
@@ -15,15 +15,15 @@ struct TreehouseInfoListView: View {
     @Binding var isPresent: Bool
     
     var body: some View {
-        LazyVStack(spacing: 14) {
+        VStack(spacing: 14) {
             RoundedRectangle(cornerRadius: 2.5)
                 .frame(width: 50, height: 4)
                 .foregroundStyle(.gray2)
                 .padding(.top, 10)
-                .padding(.bottom, 36)
+                .padding(.bottom, 25)
             
             if let data = treehouseInfoData {
-                ForEach(data) { data in
+                List(data) { data in
                     Button(action: {
                         selectedTreehouseId = data.treehouseId
                         isPresent.toggle()
@@ -34,9 +34,12 @@ struct TreehouseInfoListView: View {
                                          currentTreeHouse: data.currentTreeHouse
                         )
                     }
+                    .buttonStyle(PlainButtonStyle())
+                    .listRowInsets(EdgeInsets(top: 7, leading: 16, bottom: 7, trailing: 16))
+                    .listRowSeparator(.hidden)
                 }
-            } else {
-                // TODO: - 빈 화면 넣어야 합니다.
+                .listStyle(PlainListStyle())
+                .frame(height: calculateHeight(for: data.count))
             }
             
             Button(action: {
@@ -54,10 +57,18 @@ struct TreehouseInfoListView: View {
                     .background(.treeBlack)
                     .cornerRadius(12)
             }
+            .padding(.horizontal, 16)
         }
-        .padding(.horizontal, 16)
-        .padding(.bottom, 34+29)
+        .padding(.bottom, SizeLiterals.Screen.screenHeight * (34+29) / 852)
         .background(.grayscaleWhite)
         .selectCornerRadius(radius: 20, corners: [.topLeft, .topRight])
+    }
+    
+    private func calculateHeight(for itemCount: Int) -> CGFloat {
+        if itemCount == 1 {
+            return 100
+        } else {
+            return 170
+        }
     }
 }

--- a/Treehouse/Treehouse/ViewRouter/CreateTreehouseRouter.swift
+++ b/Treehouse/Treehouse/ViewRouter/CreateTreehouseRouter.swift
@@ -17,23 +17,25 @@ enum CreateTreehouseRouter: Router {
     case sendInvitationView
 
     func buildView(_ viewModel: BaseViewModel?) -> AnyView {
-        if let viewModel = viewModel as? CreateTreehouseViewModel {
-            switch self {
-            case .createTreehouseNameView:
-                return AnyView(CreateTreehouseNameView()
-                    .environment(viewModel))
-            case .createTreeHallNameView:
-                return AnyView(CreateTreeHallNameView()
-                    .environment(viewModel))
-            case .previewCreatedTreehouseView:
-                return AnyView(PreviewCreatedTreehouseView()
-                    .environment(viewModel))
-            case .sendInvitationView:
-                return AnyView(SendInvitationView()
-                    .environment(viewModel))
-            }
-        } else {
-            return AnyView(EmptyView())
+        let viewModel = DIContainer.shared.getViewModel(for: "CreateTreehouseRouter") {
+            CreateTreehouseViewModel(
+                checkTreehouseNameUseCase: CheckTreehouseNameUseCase(repository: TreehouseRepositoryImpl()),
+                createTreehouseUseCase: CreateTreehouseUseCase(repository: TreehouseRepositoryImpl()))
+                }
+        
+        switch self {
+        case .createTreehouseNameView:
+            return AnyView(CreateTreehouseNameView()
+                .environment(viewModel))
+        case .createTreeHallNameView:
+            return AnyView(CreateTreeHallNameView()
+                .environment(viewModel))
+        case .previewCreatedTreehouseView:
+            return AnyView(PreviewCreatedTreehouseView()
+                .environment(viewModel))
+        case .sendInvitationView:
+            return AnyView(SendInvitationView()
+                .environment(viewModel))
         }
     }
 }


### PR DESCRIPTION
## 📟 관련 이슈
- Resolved: #128 

## 👷 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
- HeaderView 의 TreehouseInfoView UI 코드를 변경 ( ForEach -> List )
- HeaderView 에 존재했던 navigationDestination 위치를 TreeTabView 로 변경
- CreateTreehouseViewModel 을 주입하기 위한 DIContainer 구현

## 🚨 참고 사항
<!-- 참고 사항을 적어주세요. 없으면 지워주세요. -->

### ViewModel 을 주입하기 위한 ` DIContainer `

현재 Treehouse 를 생성하는 로직을 위해선 CreateTreehouseViewModel 이 필요합니다.

다만 해당 View 로 전환하기 위해 `navigationDestination` 을 사용하고 있고 ViewModel 를 Router 로 넘기는 구조로 되어있어 `navigationDestination` 이 있는 곳에 ViewModel 이 존재해야하는 문제점이 존재했습니다.

``` swift
enum CreateTreehouseRouter: Router {
    typealias ContentView = AnyView
    
    case createTreehouseNameView
    case createTreeHallNameView
    case previewCreatedTreehouseView
    case sendInvitationView

    func buildView(_ viewModel: BaseViewModel?) -> AnyView {
        let viewModel = DIContainer.shared.getViewModel(for: "CreateTreehouseRouter") {
            CreateTreehouseViewModel(
                checkTreehouseNameUseCase: CheckTreehouseNameUseCase(repository: TreehouseRepositoryImpl()),
                createTreehouseUseCase: CreateTreehouseUseCase(repository: TreehouseRepositoryImpl()))
                }
        
        switch self {
        case .createTreehouseNameView:
            return AnyView(CreateTreehouseNameView()
                .environment(viewModel))
        case .createTreeHallNameView:
            return AnyView(CreateTreeHallNameView()
                .environment(viewModel))
        case .previewCreatedTreehouseView:
            return AnyView(PreviewCreatedTreehouseView()
                .environment(viewModel))
        case .sendInvitationView:
            return AnyView(SendInvitationView()
                .environment(viewModel))
        }
    }
}
```

이 문제를 해결하기 위해 Router 에서 ViewModel 을 주입해야한다고 생각을 했습니다.
여기서 중요한건 해당 ViewModel 이 전역으로 공유해야한다면 미리 선언을 해주어야 하는데 buildView 를 호출할때마다 ViewModel 이 생성되면 데이터를 공유할 수 없는 문제가 생깁니다.

그렇기 떄문에 Router 에 따로 주입을 할 수있는 DIContainer 가 필요했고 다음 같이 구현을 해주었습니다.

``` swift
final class DIContainer {
    static let shared = DIContainer()

    private init() {}

    // ViewModel을 저장할 딕셔너리
    private var viewModels: [String: Any] = [:] {
        didSet {
            print(viewModels)
        }
    }

    // ViewModel 반환 메서드
    func getViewModel<T>(for key: String, createIfNeeded: () -> T) -> T {
        if let viewModel = viewModels[key] as? T {
            return viewModel
        } else {
            let viewModel = createIfNeeded()
            viewModels[key] = viewModel
            return viewModel
        }
    }
}
```

해당 View 에 맞는 ViewModel 를 주입하고자 ViewModel 을 저장하고 있는 viewModels 라는 딕셔너리가 있습니다. 
Key 값은 String 으로 되어있고 각 Router 의 이름 ( Ex. CreateTreehouseRouter ) 으로 설정을 해야합니다.

직접 String 으로 입력을 해야하는 문제점이 존재하기 때문에 이부분은 추후에 Enum 으로 관리를 할수 있도록 리펙을 진행하겠습니다.

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
