### PR TITLE
[Feat] #126 - 라이트 모드로 제한 및 총 댓글 수 UI 변경

### DIFF
--- a/Treehouse/Treehouse.xcodeproj/project.pbxproj
+++ b/Treehouse/Treehouse.xcodeproj/project.pbxproj
@@ -2374,6 +2374,7 @@
 				INFOPLIST_KEY_UILaunchStoryboardName = "Launch Screen.storyboard";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				INFOPLIST_KEY_UIUserInterfaceStyle = Light;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -2415,6 +2416,7 @@
 				INFOPLIST_KEY_UILaunchStoryboardName = "Launch Screen.storyboard";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				INFOPLIST_KEY_UIUserInterfaceStyle = Light;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/Treehouse/Treehouse/Network/Base/NetworkServiceManager.swift
+++ b/Treehouse/Treehouse/Network/Base/NetworkServiceManager.swift
@@ -129,6 +129,7 @@ extension NetworkServiceManager {
         
         // RefreshToken 이 저장되어있는지 확인
         guard let loadRefreshToken = KeychainHelper.shared.load(for: Config.refreshTokenKey) else {
+            UserDefaults.standard.set(false, forKey: Config.loginKey)
             throw NetworkError.clientError(message: "저장된 토큰이 없습니다.")
         }
         

--- a/Treehouse/Treehouse/Presentation/Feed/FeedScene/Views/CommentCountView.swift
+++ b/Treehouse/Treehouse/Presentation/Feed/FeedScene/Views/CommentCountView.swift
@@ -18,7 +18,6 @@ struct CommentCountView: View {
     var body: some View {
         ZStack(alignment: .leading) {
             Rectangle()
-//                .frame(width: SizeLiterals.Screen.screenWidth * 315 / 393, height: 40)
                 .frame(maxWidth: .infinity)
                 .frame(height: 40)
                 .foregroundColor(.gray1)
@@ -27,18 +26,11 @@ struct CommentCountView: View {
             HStack(spacing: 5) {
                 Image(.icGreenReply)
                 
-                if commentCount < 10 {
-                    Text("0\(commentCount) comments")
-                        .fontWithLineHeight(fontLevel: .body4)
-                        .foregroundStyle(.gray7)
-                } else {
-                    Text("\(commentCount) comments")
-                        .fontWithLineHeight(fontLevel: .body4)
-                        .foregroundStyle(.gray7)
-                }
+                Text("\(commentCount) comments")
+                    .fontWithLineHeight(fontLevel: .body4)
+                    .foregroundStyle(.gray7)
             }
             .padding(.leading, 12)
-//            .padding(.trailing, 180)
         }
     }
 }

--- a/Treehouse/Treehouse/Presentation/Feed/FeedScene/Views/FeedView.swift
+++ b/Treehouse/Treehouse/Presentation/Feed/FeedScene/Views/FeedView.swift
@@ -39,8 +39,6 @@ struct FeedView: View {
     @FocusState private var focusedField: FeedField?
     @FocusState private var isKeyboardShowing: Bool
     
-    @State var scrolledID: Int?
-    
     // MARK: - View
     
     var body: some View {
@@ -262,13 +260,15 @@ extension FeedView {
                             feedViewModel.currentPostId = data.postId
                         }
                     
-                    CommentCountView(commentCount: data.commentCount)
-                        .padding(.top, 10)
-                        .padding(.trailing, 16)
-                        .onTapGesture {
-                            feedViewModel.currentPostId = data.postId
-                            viewRouter.push(FeedRouter.postDetailView)
-                        }
+                    if data.commentCount > 0 {
+                        CommentCountView(commentCount: data.commentCount)
+                            .padding(.top, 10)
+                            .padding(.trailing, 16)
+                            .onTapGesture {
+                                feedViewModel.currentPostId = data.postId
+                                viewRouter.push(FeedRouter.postDetailView)
+                            }
+                    }
                 }
                 .padding(.leading, 62)
                 .padding(.bottom, 16)


### PR DESCRIPTION
## 📟 관련 이슈
- Resolved: #126 

## 👷 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
- 다크 모드 변경을 막고 라이트 모드만 사용할 수 있게 설정 ( Info 파일 변경 )
- 총 댓글 수의 자리수를 변경 ( 00 -> 0 )
- 댓글이 존재하지 않을 경우 댓글 수 UI 를 없앱니다

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
