### PR TITLE
[Fix] #104 - Treehouse 브랜치 및 유저간 브랜치를 보여주는 WebView 로직 구현

### DIFF
--- a/Treehouse/Treehouse.xcodeproj/project.pbxproj
+++ b/Treehouse/Treehouse.xcodeproj/project.pbxproj
@@ -212,6 +212,8 @@
 		3FE944172BD645C300C3A869 /* ReceivedInvitationRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FE944162BD645C300C3A869 /* ReceivedInvitationRowView.swift */; };
 		3FEC57562C8F0BDD0080DF96 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3FEC57552C8F0BDD0080DF96 /* GoogleService-Info.plist */; };
 		3FEC575D2C8F0C2B0080DF96 /* Config.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 3FEC575C2C8F0C2B0080DF96 /* Config.xcconfig */; };
+		3FEC57612C8F23B80080DF96 /* TreeBranchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEC57602C8F23B80080DF96 /* TreeBranchViewModel.swift */; };
+		3FEC57632C8F28B80080DF96 /* MemberBranchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEC57622C8F28B80080DF96 /* MemberBranchView.swift */; };
 		3FEEF75E2C69B27A002CBA53 /* ImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEEF75D2C69B27A002CBA53 /* ImageLoader.swift */; };
 		3FEEF7602C69F7B7002CBA53 /* ReadPageFeedPostUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEEF75F2C69F7B7002CBA53 /* ReadPageFeedPostUseCase.swift */; };
 		3FEEF7652C6DF7B0002CBA53 /* UINavigationController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEEF7642C6DF7B0002CBA53 /* UINavigationController+.swift */; };
@@ -511,6 +513,8 @@
 		3FEC57552C8F0BDD0080DF96 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		3FEC575C2C8F0C2B0080DF96 /* Config.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
 		3FEC575E2C8F0C760080DF96 /* ci_post_clone.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = ci_post_clone.sh; sourceTree = "<group>"; };
+		3FEC57602C8F23B80080DF96 /* TreeBranchViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TreeBranchViewModel.swift; sourceTree = "<group>"; };
+		3FEC57622C8F28B80080DF96 /* MemberBranchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberBranchView.swift; sourceTree = "<group>"; };
 		3FEEF75D2C69B27A002CBA53 /* ImageLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageLoader.swift; sourceTree = "<group>"; };
 		3FEEF75F2C69F7B7002CBA53 /* ReadPageFeedPostUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadPageFeedPostUseCase.swift; sourceTree = "<group>"; };
 		3FEEF7642C6DF7B0002CBA53 /* UINavigationController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UINavigationController+.swift"; sourceTree = "<group>"; };
@@ -850,6 +854,7 @@
 				00C2F5662C15B5560009C6A1 /* SettingView.swift */,
 				00C2F5702C1AFEBC0009C6A1 /* EditProfileView.swift */,
 				3F44C13F2C27E8DC00A5CAFE /* UserInfoView.swift */,
+				3FEC57622C8F28B80080DF96 /* MemberBranchView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -1354,6 +1359,14 @@
 			path = ViewModels;
 			sourceTree = "<group>";
 		};
+		3FEC575F2C8F23A70080DF96 /* ViewModels */ = {
+			isa = PBXGroup;
+			children = (
+				3FEC57602C8F23B80080DF96 /* TreeBranchViewModel.swift */,
+			);
+			path = ViewModels;
+			sourceTree = "<group>";
+		};
 		3FF106F62BEA073E00C52908 /* Base */ = {
 			isa = PBXGroup;
 			children = (
@@ -1830,6 +1843,7 @@
 		94D5FA852C5BD118000A9357 /* TreeBranchScene */ = {
 			isa = PBXGroup;
 			children = (
+				3FEC575F2C8F23A70080DF96 /* ViewModels */,
 				94D5FA862C5BD124000A9357 /* Views */,
 			);
 			path = TreeBranchScene;
@@ -1968,6 +1982,7 @@
 				3F6E13C62C7C7F0400F94595 /* WebViewContainer.swift in Sources */,
 				3F8530EA2C5281E5003FA07A /* CustomAsyncImage.swift in Sources */,
 				3F06C3072BFDEB40002B771B /* PostReactionCommentRequestDTO.swift in Sources */,
+				3FEC57632C8F28B80080DF96 /* MemberBranchView.swift in Sources */,
 				3F1936142C6287B600584939 /* PostCheckNotificationsResponseDTO.swift in Sources */,
 				3FA175E32C1AC47A00A57987 /* PresignedURLResponseEntity.swift in Sources */,
 				3F06C2FA2BFDC2E8002B771B /* FeedAPI.swift in Sources */,
@@ -2236,6 +2251,7 @@
 				3FFA73142C3178F800C3AF4F /* Image+.swift in Sources */,
 				0012366F2BD1831300CEAC53 /* PhoneNumberSearchBar.swift in Sources */,
 				3F8171662C43A27300CEE21E /* UserPhoneViewModel.swift in Sources */,
+				3FEC57612C8F23B80080DF96 /* TreeBranchViewModel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Treehouse/Treehouse/Global/Components/TabView/TreeTabView.swift
+++ b/Treehouse/Treehouse/Global/Components/TabView/TreeTabView.swift
@@ -91,6 +91,9 @@ struct TreeTabView: View {
     private func currentTreehousePerformRequest() {
         if let currentTreehouseId = currentTreehouseInfoViewModel.currentTreehouseId {
             viewRouter.selectedTreehouseId = currentTreehouseId
+            
+            currentTreehouseInfoViewModel.memberId = userInfoViewModel.userInfo?.findTreehouse(id: currentTreehouseId)?.treehouseMemberId ?? 0
+            
             Task {
                 await currentTreehouseInfoViewModel.getReadTreehouseInfo(treehouseId: currentTreehouseId)
             }

--- a/Treehouse/Treehouse/Global/WebView/WebView.swift
+++ b/Treehouse/Treehouse/Global/WebView/WebView.swift
@@ -27,21 +27,20 @@ class WebViewNavigationDelegate: NSObject, WKNavigationDelegate {
 }
 
 struct WebView: UIViewRepresentable {
-    let url: String
+    @Binding var url: String
     @Binding var isLoading: Bool
     
     func makeUIView(context: Context) -> WKWebView {
         let webView = WKWebView()
         webView.navigationDelegate = context.coordinator
-
-        if let url = URL(string: url) {
-            webView.load(URLRequest(url: url))
-        }
-        
         return webView
     }
     
-    func updateUIView(_ uiView: WKWebView, context: Context) { }
+    func updateUIView(_ uiView: WKWebView, context: Context) {
+        if let url = URL(string: url), url != uiView.url {
+            uiView.load(URLRequest(url: url))
+        }
+    }
     
     func makeCoordinator() -> WebViewNavigationDelegate {
         WebViewNavigationDelegate(isLoading: $isLoading)

--- a/Treehouse/Treehouse/Global/WebView/WebViewContainer.swift
+++ b/Treehouse/Treehouse/Global/WebView/WebViewContainer.swift
@@ -11,12 +11,12 @@ struct WebViewContainer: View {
     
     @Environment(\.presentationMode) var presentationMode
     @State var isLoading = true
-    let url: String
+    @State var url: String
     
     var body: some View {
         NavigationStack {
             ZStack {
-                WebView(url: url, isLoading: $isLoading)
+                WebView(url: $url, isLoading: $isLoading)
                 
                 if isLoading {
                     LottieView(lottieFile: "treehouse_loading", speed: 1)

--- a/Treehouse/Treehouse/Presentation/Feed/FeedScene/Views/FeedHomeView.swift
+++ b/Treehouse/Treehouse/Presentation/Feed/FeedScene/Views/FeedHomeView.swift
@@ -90,6 +90,8 @@ struct FeedHomeView: View {
                 viewRouter.buildScene(inputRouter: router, viewModel: userInfoViewModel)
             case .memberProfileView:
                 viewRouter.buildScene(inputRouter: router, viewModel: feedViewModel)
+            case .memberBranchView:
+                viewRouter.buildScene(inputRouter: router, viewModel: currentTreehouseInfoViewModel)
             }
         }
         .onAppear {

--- a/Treehouse/Treehouse/Presentation/Notification/NotificationScene/ViewModels/NotificationViewModel.swift
+++ b/Treehouse/Treehouse/Presentation/Notification/NotificationScene/ViewModels/NotificationViewModel.swift
@@ -60,7 +60,7 @@ extension NotificationViewModel {
         case .success(let response):
             
             await MainActor.run {
-                notificationData = response.notifications
+                notificationData = response.notifications.reversed()
                 
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
                     self.isLoading = false

--- a/Treehouse/Treehouse/Presentation/Profile/Views/MemberBranchView.swift
+++ b/Treehouse/Treehouse/Presentation/Profile/Views/MemberBranchView.swift
@@ -1,0 +1,53 @@
+//
+//  MemberBranchView.swift
+//  Treehouse
+//
+//  Created by ParkJunHyuk on 9/9/24.
+//
+
+import SwiftUI
+
+struct MemberBranchView: View {
+    
+    // MARK: - State Property
+    @Environment(ViewRouter.self) var viewRouter: ViewRouter
+    @Environment(CurrentTreehouseInfoViewModel.self) var currentTreehouseInfoViewModel
+    @State var treeBranchViewModel = TreeBranchViewModel(webViewType: .memberBranch)
+    
+    @AppStorage("treehouseId") private var selectedTreehouseId: Int = -1
+    @State var isLoading = true
+    
+    let memberId: Int
+    
+    // MARK: - View
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            ZStack {
+                if treeBranchViewModel.webViewUrl.isEmpty {
+                    VStack {
+                        Spacer()
+                        
+                        LottieView(lottieFile: "treehouse_loading", speed: 1)
+                            .frame(width: 100, height: 100)
+                        
+                        Spacer()
+                    }
+                } else {
+                    WebView(url: $treeBranchViewModel.webViewUrl, isLoading: $isLoading)
+                }
+            }
+        }
+        .navigationTitle("브랜치 보기")
+        .navigationBarTitleDisplayMode(.inline)
+        .onAppear {
+            Task {
+                await treeBranchViewModel.changetreeBranchUrl(treehouseId: selectedTreehouseId, myMemberId: currentTreehouseInfoViewModel.memberId, memberId: memberId)
+            }
+        }
+    }
+}
+
+#Preview {
+    MemberBranchView(memberId: 0)
+}

--- a/Treehouse/Treehouse/Presentation/Profile/Views/MemberProfileView.swift
+++ b/Treehouse/Treehouse/Presentation/Profile/Views/MemberProfileView.swift
@@ -36,7 +36,8 @@ struct MemberProfileView: View {
                                      treeHouseCount: data.treehouseCount,
                                      root: "\(data.fromMe)",
                                      inviteAction: nil,
-                                     branchAction: nil,
+                                     branchAction: { viewRouter.push(ProfileRouter.memberBranchView(treehouseId: feedViewModel.currentTreehouseId ?? 0, memberId: data.memberId))
+                                    },
                                      profileAction: nil)
                         .padding(.top, 15)
                     }
@@ -85,19 +86,6 @@ struct MemberProfileView: View {
             }
             .refreshable {
                 await memberProfileViewModel.performAsyncTasks()
-            }
-            
-            if memberProfileViewModel.isLoading == true {
-                VStack {
-                    Spacer()
-                    
-                    LottieView(lottieFile: "treehouse_loading", speed: 1)
-                        .frame(width: 100, height: 100)
-                    
-                    Spacer()
-                }
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .background(.grayscaleWhite)
             }
         }
         .navigationTitle(memberProfileViewModel.title)

--- a/Treehouse/Treehouse/Presentation/Profile/Views/UserInfoView.swift
+++ b/Treehouse/Treehouse/Presentation/Profile/Views/UserInfoView.swift
@@ -140,8 +140,8 @@ private extension UserInfoView {
                     branchAction?()
                 }) {
                     Text(StringLiterals.Profile.buttonLabel2)
-                        .font(.fontGuide(.body4))
-                        .foregroundStyle(.gray1)
+                        .fontWithLineHeight(fontLevel: .body4)
+                        .foregroundStyle(.grayscaleWhite)
                         .frame(maxWidth: .infinity)
                         .padding(.vertical, 14)
                         .background(.treeGreen)
@@ -152,8 +152,8 @@ private extension UserInfoView {
                     inviteAction?()
                 }) {
                     Text(StringLiterals.Profile.buttonLabel3)
-                        .font(.fontGuide(.body4))
-                        .foregroundStyle(.gray1)
+                        .fontWithLineHeight(fontLevel: .body4)
+                        .foregroundStyle(.grayscaleWhite)
                         .frame(maxWidth: .infinity)
                         .padding(.vertical, 14)
                         .background(.treeBlack)
@@ -165,8 +165,8 @@ private extension UserInfoView {
                 profileAction?()
             }) {
                 Text(StringLiterals.Profile.buttonLabel1)
-                    .font(.fontGuide(.body4))
-                    .foregroundStyle(.gray1)
+                    .fontWithLineHeight(fontLevel: .body4)
+                    .foregroundStyle(.grayscaleWhite)
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 14)
                     .background(.treeBlack)

--- a/Treehouse/Treehouse/Presentation/TreeBranch/TreeBranchScene/ViewModels/TreeBranchViewModel.swift
+++ b/Treehouse/Treehouse/Presentation/TreeBranch/TreeBranchScene/ViewModels/TreeBranchViewModel.swift
@@ -1,0 +1,43 @@
+//
+//  TreeBranchViewModel.swift
+//  Treehouse
+//
+//  Created by ParkJunHyuk on 9/9/24.
+//
+
+import Foundation
+import Observation
+
+enum WebViewType {
+    case treeBranch
+    case memberBranch
+}
+
+@Observable
+final class TreeBranchViewModel: BaseViewModel {
+    
+    var webViewType: WebViewType
+    var webViewUrl = ""
+    
+    init(webViewType: WebViewType) {
+        self.webViewType = webViewType
+    }
+    
+    func changetreeBranchUrl(treehouseId: Int?, myMemberId: Int? = nil, memberId: Int?) async {
+        if let token = KeychainHelper.shared.load(for: Config.accessTokenKey) {
+            guard let treeId = treehouseId else { return }
+            
+            switch webViewType {
+            case .treeBranch:
+                webViewUrl = Config.webFrontURL + "tree/\(treeId)?token=\(token)"
+                print("주소:", webViewUrl)
+            case .memberBranch:
+                guard let memberId = memberId else { return }
+                guard let myMemberId = myMemberId else { return }
+                
+                webViewUrl = Config.webFrontURL + "member/\(treeId)?&sourceMemberId=\(myMemberId)&targetMemberId=\(memberId)&token=\(token)"
+                print("주소:", webViewUrl)
+            }
+        }
+    }
+}

--- a/Treehouse/Treehouse/Presentation/TreeBranch/TreeBranchScene/Views/TreeBranchView.swift
+++ b/Treehouse/Treehouse/Presentation/TreeBranch/TreeBranchScene/Views/TreeBranchView.swift
@@ -8,11 +8,40 @@
 import SwiftUI
 
 struct TreeBranchView: View {
+    
+    // MARK: - State Property
     @Environment(ViewRouter.self) var viewRouter: ViewRouter
+    @Environment(CurrentTreehouseInfoViewModel.self) var currentTreehouseInfoViewModel
+    @State var treeBranchViewModel = TreeBranchViewModel(webViewType: .treeBranch)
+    
+    @AppStorage("treehouseId") private var selectedTreehouseId: Int = -1
+    @State var isLoading = true
+    @State var url = ""
+    
+    // MARK: - View
         
     var body: some View {
-        VStack {
-            Spacer()
+        VStack(spacing: 0) {
+            HeaderView()
+                .frame(height: 56)
+                .frame(maxWidth: .infinity)
+                .background(.grayscaleWhite)
+                .environment(currentTreehouseInfoViewModel)
+            
+            ZStack {
+                if treeBranchViewModel.webViewUrl.isEmpty {
+                    VStack {
+                        Spacer()
+                        
+                        LottieView(lottieFile: "treehouse_loading", speed: 1)
+                            .frame(width: 100, height: 100)
+                        
+                        Spacer()
+                    }
+                } else {
+                    WebView(url: $treeBranchViewModel.webViewUrl, isLoading: $isLoading)
+                }
+            }
             
             Button(action: {
                 viewRouter.push(InvitationRouter.inviteBranchView)
@@ -26,17 +55,27 @@ struct TreeBranchView: View {
                     Text("초대장 확인하기")
                         .fontWithLineHeight(fontLevel: .body4)
                 }
+                .frame(maxWidth: .infinity)
+                .frame(height: 48)
+                .foregroundStyle(.gray1)
+                .background(.treeBlack)
+                .cornerRadius(10)
             }
-            .frame(maxWidth: .infinity)
-            .frame(height: 48)
-            .foregroundStyle(.gray1)
-            .background(.treeBlack)
-            .cornerRadius(10)
             .padding(.horizontal, 16)
         }
         .padding(.bottom, 16)
         .navigationDestination(for: InvitationRouter.self) { router in
             viewRouter.buildScene(inputRouter: router)
+        }
+        .onAppear {
+            Task {
+                await treeBranchViewModel.changetreeBranchUrl(treehouseId: selectedTreehouseId, memberId: nil)
+            }
+        }
+        .onChange(of: selectedTreehouseId) {  _, newValue in
+            Task {
+                await treeBranchViewModel.changetreeBranchUrl(treehouseId: selectedTreehouseId, memberId: nil)
+            }
         }
     }
 }

--- a/Treehouse/Treehouse/ViewRouter/ProfileRouter.swift
+++ b/Treehouse/Treehouse/ViewRouter/ProfileRouter.swift
@@ -13,6 +13,7 @@ enum ProfileRouter: Router {
     
     case editProfileView(treehouseId: Int, memberId: Int, memberProfileUrl: String, memberName: String, bio: String)
     case memberProfileView(treehouseId: Int, memberId: Int)
+    case memberBranchView(treehouseId: Int, memberId: Int)
     
     func buildView(_ viewModel: BaseViewModel?) -> ContentView {
         if let viewModel = viewModel as? UserInfoViewModel {
@@ -47,7 +48,15 @@ enum ProfileRouter: Router {
             default:
                 return AnyView(EmptyView())
             }
-        } else {
+        } else if let viewModel = viewModel as? CurrentTreehouseInfoViewModel {
+            switch self {
+            case .memberBranchView(let treehouseId, let memberId):
+                return AnyView(MemberBranchView(memberId: memberId).environment(viewModel))
+            default:
+                return AnyView(EmptyView())
+            }
+        }
+        else {
             return AnyView(EmptyView())
         }
     }


### PR DESCRIPTION
## 📟 관련 이슈
- Resolved: #104 

<br>

## 👷 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
- webUrl 변경시 다시 웹을 리로드하는 로직 구현
- 가입된 Treehouse 브랜치를 보여주는 `TreeBranchView` 구현
- 유저 간 브랜치를 보여주는 `MemberBranchView` 구현
- 알람 데이터를 최신순으로 변경
- `fontWithLineHeight` ViewModifier 변경 및 색상 변경

<br>

## 🚨 참고 사항
<!-- 참고 사항을 적어주세요. 없으면 지워주세요. -->

### ` WebView ` 사용방법

``` swift
WebView(url: $treeBranchViewModel.webViewUrl, isLoading: $isLoading)
```

다음과 같이 `url` 를 Binding 을 하고 Web이 로딩이 완료될때까지 보여줄 인디케이터를 이미지를 위한 `isLoading` Binding 변수를 설정해주어야 합니다!

<br>

## 📸 스크린샷
|기능|Treehouse 브랜치|유저 간 브랜치|
|:--:|:--:|:--:|
|Img|<img src = "https://github.com/user-attachments/assets/6a9de987-debb-42ff-b14a-d243ef1ecb2f" width ="250">|<img src = "https://github.com/user-attachments/assets/c8e8b815-d35b-4b86-9717-eefe7f5ec76d" width ="250">|

<br>

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
