### PR TITLE
[Feat] #121 - FCM Token 저장 및 Push 알람 동의 API 구현 및 관련 로직 구현

### DIFF
--- a/Treehouse/Treehouse.xcodeproj/project.pbxproj
+++ b/Treehouse/Treehouse.xcodeproj/project.pbxproj
@@ -212,6 +212,16 @@
 		3FE944172BD645C300C3A869 /* ReceivedInvitationRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FE944162BD645C300C3A869 /* ReceivedInvitationRowView.swift */; };
 		3FEC57562C8F0BDD0080DF96 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3FEC57552C8F0BDD0080DF96 /* GoogleService-Info.plist */; };
 		3FEC575D2C8F0C2B0080DF96 /* Config.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 3FEC575C2C8F0C2B0080DF96 /* Config.xcconfig */; };
+		3FEC57652C8F484F0080DF96 /* PostRegisterFCMTokenResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEC57642C8F484E0080DF96 /* PostRegisterFCMTokenResponseDTO.swift */; };
+		3FEC57672C8F48630080DF96 /* PostRegisterPushAgreeResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEC57662C8F48630080DF96 /* PostRegisterPushAgreeResponseDTO.swift */; };
+		3FEC57692C8F48770080DF96 /* PostRegisterFCMTokenRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEC57682C8F48770080DF96 /* PostRegisterFCMTokenRequestDTO.swift */; };
+		3FEC576B2C8F48880080DF96 /* PostRegisterPushAgreeRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEC576A2C8F48880080DF96 /* PostRegisterPushAgreeRequestDTO.swift */; };
+		3FEC576D2C8F493B0080DF96 /* RegisterFCMTokenUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEC576C2C8F493B0080DF96 /* RegisterFCMTokenUseCase.swift */; };
+		3FEC576F2C8F49460080DF96 /* RegisterPushAgreeUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEC576E2C8F49460080DF96 /* RegisterPushAgreeUseCase.swift */; };
+		3FEC57712C8F49890080DF96 /* RegisterFCMTokenResponseEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEC57702C8F49890080DF96 /* RegisterFCMTokenResponseEntity.swift */; };
+		3FEC57732C8F499A0080DF96 /* RegisterPushAgreeResponseEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEC57722C8F499A0080DF96 /* RegisterPushAgreeResponseEntity.swift */; };
+		3FEC57752C8F49F60080DF96 /* FCMTokenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEC57742C8F49F60080DF96 /* FCMTokenViewModel.swift */; };
+		3FEC57772C8F4A080080DF96 /* RegisterPushNotiViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEC57762C8F4A080080DF96 /* RegisterPushNotiViewModel.swift */; };
 		3FEEF75E2C69B27A002CBA53 /* ImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEEF75D2C69B27A002CBA53 /* ImageLoader.swift */; };
 		3FEEF7602C69F7B7002CBA53 /* ReadPageFeedPostUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEEF75F2C69F7B7002CBA53 /* ReadPageFeedPostUseCase.swift */; };
 		3FEEF7652C6DF7B0002CBA53 /* UINavigationController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEEF7642C6DF7B0002CBA53 /* UINavigationController+.swift */; };
@@ -511,6 +521,16 @@
 		3FEC57552C8F0BDD0080DF96 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		3FEC575C2C8F0C2B0080DF96 /* Config.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
 		3FEC575E2C8F0C760080DF96 /* ci_post_clone.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = ci_post_clone.sh; sourceTree = "<group>"; };
+		3FEC57642C8F484E0080DF96 /* PostRegisterFCMTokenResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostRegisterFCMTokenResponseDTO.swift; sourceTree = "<group>"; };
+		3FEC57662C8F48630080DF96 /* PostRegisterPushAgreeResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostRegisterPushAgreeResponseDTO.swift; sourceTree = "<group>"; };
+		3FEC57682C8F48770080DF96 /* PostRegisterFCMTokenRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostRegisterFCMTokenRequestDTO.swift; sourceTree = "<group>"; };
+		3FEC576A2C8F48880080DF96 /* PostRegisterPushAgreeRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostRegisterPushAgreeRequestDTO.swift; sourceTree = "<group>"; };
+		3FEC576C2C8F493B0080DF96 /* RegisterFCMTokenUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterFCMTokenUseCase.swift; sourceTree = "<group>"; };
+		3FEC576E2C8F49460080DF96 /* RegisterPushAgreeUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterPushAgreeUseCase.swift; sourceTree = "<group>"; };
+		3FEC57702C8F49890080DF96 /* RegisterFCMTokenResponseEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterFCMTokenResponseEntity.swift; sourceTree = "<group>"; };
+		3FEC57722C8F499A0080DF96 /* RegisterPushAgreeResponseEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterPushAgreeResponseEntity.swift; sourceTree = "<group>"; };
+		3FEC57742C8F49F60080DF96 /* FCMTokenViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FCMTokenViewModel.swift; sourceTree = "<group>"; };
+		3FEC57762C8F4A080080DF96 /* RegisterPushNotiViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterPushNotiViewModel.swift; sourceTree = "<group>"; };
 		3FEEF75D2C69B27A002CBA53 /* ImageLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageLoader.swift; sourceTree = "<group>"; };
 		3FEEF75F2C69F7B7002CBA53 /* ReadPageFeedPostUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadPageFeedPostUseCase.swift; sourceTree = "<group>"; };
 		3FEEF7642C6DF7B0002CBA53 /* UINavigationController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UINavigationController+.swift"; sourceTree = "<group>"; };
@@ -707,6 +727,8 @@
 				3F94635E2C11650600229940 /* CheckUserPhoneResponseEntity.swift */,
 				3F81715C2C43847A00CEE21E /* ExistsUserLoginResponseEntity.swift */,
 				3F6E13C32C7B7E4900F94595 /* DeleteUserResponseEntity.swift */,
+				3FEC57702C8F49890080DF96 /* RegisterFCMTokenResponseEntity.swift */,
+				3FEC57722C8F499A0080DF96 /* RegisterPushAgreeResponseEntity.swift */,
 			);
 			path = Register;
 			sourceTree = "<group>";
@@ -817,6 +839,8 @@
 				3F5150492C0E065600AD05C3 /* RegisterTreeMemberUseCase.swift */,
 				3F94635C2C11644600229940 /* CheckUserPhoneUseCase.swift */,
 				3F81715E2C4384E600CEE21E /* ExistsUserLoginUserCase.swift */,
+				3FEC576C2C8F493B0080DF96 /* RegisterFCMTokenUseCase.swift */,
+				3FEC576E2C8F49460080DF96 /* RegisterPushAgreeUseCase.swift */,
 				3F6E13C12C7B7DFD00F94595 /* DeleteUserUseCase.swift */,
 			);
 			path = Register;
@@ -1232,6 +1256,8 @@
 				3F8845FF2BF095F60021FB79 /* UserSettingViewModel.swift */,
 				3F8171632C4399B700CEE21E /* UserLoginViewModel.swift */,
 				3F8171652C43A27300CEE21E /* UserPhoneViewModel.swift */,
+				3FEC57742C8F49F60080DF96 /* FCMTokenViewModel.swift */,
+				3FEC57762C8F4A080080DF96 /* RegisterPushNotiViewModel.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -1424,6 +1450,8 @@
 				3F9463602C11662200229940 /* PostCheckUserPhoneResponseDTO.swift */,
 				3F81715A2C43833100CEE21E /* PostExistsUserLoginResponseDTO.swift */,
 				3F6E13BF2C7B779D00F94595 /* DeleteUserResponseDTO.swift */,
+				3FEC57642C8F484E0080DF96 /* PostRegisterFCMTokenResponseDTO.swift */,
+				3FEC57662C8F48630080DF96 /* PostRegisterPushAgreeResponseDTO.swift */,
 			);
 			path = Response;
 			sourceTree = "<group>";
@@ -1438,6 +1466,8 @@
 				3FF1071C2BEA0A5300C52908 /* PostReissueTokenRequestDTO.swift */,
 				3F94635A2C11628A00229940 /* PostCheckUserPhoneRequestDTO.swift */,
 				3F5189E62C520B2E00982B5B /* PostExistsUserLoginRequestDTO.swift */,
+				3FEC57682C8F48770080DF96 /* PostRegisterFCMTokenRequestDTO.swift */,
+				3FEC576A2C8F48880080DF96 /* PostRegisterPushAgreeRequestDTO.swift */,
 			);
 			path = Request;
 			sourceTree = "<group>";
@@ -1955,6 +1985,7 @@
 				3F3DAE982C57D09800C1424C /* ReportCommentUseCase.swift in Sources */,
 				3FF48FD42C4DF69E00A6DD8A /* PostViewModel.swift in Sources */,
 				3FDCDA332C63B84400C7F7B6 /* PostCheckTreehouseNameRequestDTO.swift in Sources */,
+				3FEC576F2C8F49460080DF96 /* RegisterPushAgreeUseCase.swift in Sources */,
 				3F8AE70E2C5A2AEF00E999C4 /* PatchUpdateFeedPostRequestDTO.swift in Sources */,
 				3F51505A2C0ED99400AD05C3 /* CheckInvitationsReponseEntity.swift in Sources */,
 				3F3DAE9B2C588CE900C1424C /* TreehouseViewModel.swift in Sources */,
@@ -1968,6 +1999,7 @@
 				3F6E13C62C7C7F0400F94595 /* WebViewContainer.swift in Sources */,
 				3F8530EA2C5281E5003FA07A /* CustomAsyncImage.swift in Sources */,
 				3F06C3072BFDEB40002B771B /* PostReactionCommentRequestDTO.swift in Sources */,
+				3FEC57672C8F48630080DF96 /* PostRegisterPushAgreeResponseDTO.swift in Sources */,
 				3F1936142C6287B600584939 /* PostCheckNotificationsResponseDTO.swift in Sources */,
 				3FA175E32C1AC47A00A57987 /* PresignedURLResponseEntity.swift in Sources */,
 				3F06C2FA2BFDC2E8002B771B /* FeedAPI.swift in Sources */,
@@ -2046,8 +2078,10 @@
 				3F8835832BCBF97D0021C8AB /* SetMemberBioView.swift in Sources */,
 				3F06C3102BFDF2D4002B771B /* PatchUpdateFeedPostResponseDTO.swift in Sources */,
 				3FFA73162C318CC000C3AF4F /* Data+.swift in Sources */,
+				3FEC576B2C8F48880080DF96 /* PostRegisterPushAgreeRequestDTO.swift in Sources */,
 				3FF490242C51163400A6DD8A /* ReadMyProfileInfoUseCase.swift in Sources */,
 				00CF35942BC2E20300D9E332 /* StringLiterals.swift in Sources */,
+				3FEC57712C8F49890080DF96 /* RegisterFCMTokenResponseEntity.swift in Sources */,
 				3F81716A2C43FEB800CEE21E /* CreateCommentUseCase.swift in Sources */,
 				3F9463612C11662200229940 /* PostCheckUserPhoneResponseDTO.swift in Sources */,
 				3F94635B2C11628A00229940 /* PostCheckUserPhoneRequestDTO.swift in Sources */,
@@ -2091,7 +2125,10 @@
 				94D388D32C257BBC0058231B /* CreateTreeHallNameView.swift in Sources */,
 				3F88357F2BCBA5C10021C8AB /* SetMemberProfileNameView.swift in Sources */,
 				3F81715D2C43847A00CEE21E /* ExistsUserLoginResponseEntity.swift in Sources */,
+				3FEC576D2C8F493B0080DF96 /* RegisterFCMTokenUseCase.swift in Sources */,
 				3FF48FE92C50E8DE00A6DD8A /* TreehouseAPI.swift in Sources */,
+				3FEC57772C8F4A080080DF96 /* RegisterPushNotiViewModel.swift in Sources */,
+				3FEC57692C8F48770080DF96 /* PostRegisterFCMTokenRequestDTO.swift in Sources */,
 				3FE6B7F62C7EECD800457DD0 /* PostInvitationResponseDTO.swift in Sources */,
 				3FF48FF02C50E9BF00A6DD8A /* GetReadTreehouseInfoResponseDTO.swift in Sources */,
 				3F0AC3012C2D53C8009F8F46 /* UserInfoDataSource.swift in Sources */,
@@ -2109,6 +2146,7 @@
 				3FE944172BD645C300C3A869 /* ReceivedInvitationRowView.swift in Sources */,
 				94D100182C0C2A1900025D43 /* CommentCountView.swift in Sources */,
 				3FF107172BEA0A2A00C52908 /* PostCheckUserNameRequestDTO.swift in Sources */,
+				3FEC57652C8F484F0080DF96 /* PostRegisterFCMTokenResponseDTO.swift in Sources */,
 				3F8171682C43FE6F00CEE21E /* CreateCommentResponseEntity.swift in Sources */,
 				9499D9522BF1C5AD007CC6CF /* NetworkErrorCode.swift in Sources */,
 				0087C29C2BE3609C004CED9C /* RegisterAPI.swift in Sources */,
@@ -2190,6 +2228,7 @@
 				00F8BB452BC9A43000B23AE4 /* LoginView.swift in Sources */,
 				3FF106FA2BEA077E00C52908 /* BaseRequest.swift in Sources */,
 				008B67FE2BC57EEF001E3AB5 /* VerificationView.swift in Sources */,
+				3FEC57752C8F49F60080DF96 /* FCMTokenViewModel.swift in Sources */,
 				3F5150502C0EA09F00AD05C3 /* AcceptInvitationTreeMemberEntity.swift in Sources */,
 				3FE6B7F42C7EEBFD00457DD0 /* PostInvitationRequestDTO.swift in Sources */,
 				3FBFBA802BC3DA6C00B6A446 /* View+.swift in Sources */,
@@ -2202,6 +2241,7 @@
 				009B71142BFF41BD009A741C /* FeedHeaderView.swift in Sources */,
 				00C2F56F2C18667E0009C6A1 /* MemberGroupRow.swift in Sources */,
 				3F8835812BCBC4A40021C8AB /* SetMemberProfileImage.swift in Sources */,
+				3FEC57732C8F499A0080DF96 /* RegisterPushAgreeResponseEntity.swift in Sources */,
 				3F8AE7002C59BD6E00E999C4 /* EmojiView.swift in Sources */,
 				3FF490072C50FDB600A6DD8A /* CreateTreehouseResponseEntity.swift in Sources */,
 				3F1BE1302C2118F600D3AF1D /* UploadImageToAWSUseCase.swift in Sources */,

--- a/Treehouse/Treehouse/Data/Repositories/RegisterRepositoryImpl.swift
+++ b/Treehouse/Treehouse/Data/Repositories/RegisterRepositoryImpl.swift
@@ -63,6 +63,28 @@ final class RegisterRepositoryImpl: RegisterRepositoryProtocol {
         }
     }
     
+    func postRegisterFCMToken(token: String) async -> Result<RegisterFCMTokenResponseEntity, NetworkError>  {
+        do {
+            let response = try await registerService.postRegisterFCMToken(token: token)
+            return .success(response.toDomain())
+        } catch let error as NetworkError {
+            return .failure(error)
+        } catch {
+            return .failure(NetworkError.unknown)
+        }
+    }
+    
+    func postRegisterPushAgree(pushAgree: Bool) async -> Result<RegisterPushAgreeResponseEntity, NetworkError> {
+        do {
+            let response = try await registerService.postRegisterPushAgree(pushAgree: pushAgree)
+            return .success(response.toDomain())
+        } catch let error as NetworkError {
+            return .failure(error)
+        } catch {
+            return .failure(NetworkError.unknown)
+        }
+    }
+    
     func deleteUser() async -> Result<DeleteUserResponseEntity, NetworkError> {
         do {
             let response = try await registerService.deleteUser()

--- a/Treehouse/Treehouse/Domain/Entities/Register/RegisterFCMTokenResponseEntity.swift
+++ b/Treehouse/Treehouse/Domain/Entities/Register/RegisterFCMTokenResponseEntity.swift
@@ -1,0 +1,13 @@
+//
+//  RegisterFCMTokenResponseEntity.swift
+//  Treehouse
+//
+//  Created by ParkJunHyuk on 9/10/24.
+//
+
+import Foundation
+
+struct RegisterFCMTokenResponseEntity: Decodable {
+    let userId: Int
+    let saveFcmToken: Bool
+}

--- a/Treehouse/Treehouse/Domain/Entities/Register/RegisterPushAgreeResponseEntity.swift
+++ b/Treehouse/Treehouse/Domain/Entities/Register/RegisterPushAgreeResponseEntity.swift
@@ -1,0 +1,13 @@
+//
+//  RegisterPushAgreeResponseEntity.swift
+//  Treehouse
+//
+//  Created by ParkJunHyuk on 9/10/24.
+//
+
+import Foundation
+
+struct RegisterPushAgreeResponseEntity: Decodable {
+    let userId: Int
+    let pushAgree: Bool
+}

--- a/Treehouse/Treehouse/Domain/RepositoryProtocol/RegisterRepositoryProtocol.swift
+++ b/Treehouse/Treehouse/Domain/RepositoryProtocol/RegisterRepositoryProtocol.swift
@@ -13,5 +13,7 @@ protocol RegisterRepositoryProtocol {
     func postRegisterTreeMember(requestDTO: PostRegisterTreeMemberRequestDTO) async -> Result<RegisterTreeMemberResponseEntity, NetworkError>
     func postCheckUserPhone(phoneNumber: String) async -> Result<CheckUserPhoneResponseEntity, NetworkError>
     func postExistsUserLogin(phoneNumber: String) async -> Result<ExistsUserLoginResponseEntity, NetworkError>
+    func postRegisterFCMToken(token: String) async -> Result<RegisterFCMTokenResponseEntity, NetworkError>
+    func postRegisterPushAgree(pushAgree: Bool) async -> Result<RegisterPushAgreeResponseEntity, NetworkError>
     func deleteUser() async -> Result<DeleteUserResponseEntity, NetworkError>
 }

--- a/Treehouse/Treehouse/Domain/UseCases/Register/RegisterFCMTokenUseCase.swift
+++ b/Treehouse/Treehouse/Domain/UseCases/Register/RegisterFCMTokenUseCase.swift
@@ -1,0 +1,39 @@
+//
+//  RegisterFCMTokenUseCase.swift
+//  Treehouse
+//
+//  Created by ParkJunHyuk on 9/10/24.
+//
+
+import Foundation
+import FirebaseMessaging
+
+protocol PostRegisterFCMTokenUseCaseProtocol {
+    func execute() async -> Result<RegisterFCMTokenResponseEntity, NetworkError>
+}
+
+final class RegisterFCMTokenUseCase: PostRegisterFCMTokenUseCaseProtocol {
+    private let repository: RegisterRepositoryProtocol
+    
+    init(repository: RegisterRepositoryProtocol) {
+        self.repository = repository
+    }
+    
+    func execute() async -> Result<RegisterFCMTokenResponseEntity, NetworkError> {
+        let fcmToken = await getFCMToken()
+        
+        return await repository.postRegisterFCMToken(token: fcmToken)
+    }
+    
+    func getFCMToken() async -> String {
+        do {
+            let token = try await Messaging.messaging().token()
+            print("FCM registration token: \(token)")
+            // 여기서 토큰을 사용하거나 저장할 수 있습니다.
+            return token
+        } catch {
+            print("Error fetching FCM registration token: \(error)")
+            return ""
+        }
+    }
+}

--- a/Treehouse/Treehouse/Domain/UseCases/Register/RegisterPushAgreeUseCase.swift
+++ b/Treehouse/Treehouse/Domain/UseCases/Register/RegisterPushAgreeUseCase.swift
@@ -1,0 +1,24 @@
+//
+//  RegisterPushAgreeUseCase.swift
+//  Treehouse
+//
+//  Created by ParkJunHyuk on 9/10/24.
+//
+
+import Foundation
+
+protocol PostRegisterPushAgreeUseCaseProtocol {
+    func execute(pushAgree: Bool) async -> Result<RegisterPushAgreeResponseEntity, NetworkError>
+}
+
+final class RegisterPushAgreeUseCase: PostRegisterPushAgreeUseCaseProtocol {
+    private let repository: RegisterRepositoryProtocol
+    
+    init(repository: RegisterRepositoryProtocol) {
+        self.repository = repository
+    }
+    
+    func execute(pushAgree: Bool) async -> Result<RegisterPushAgreeResponseEntity, NetworkError> {
+        return await repository.postRegisterPushAgree(pushAgree: pushAgree)
+    }
+}

--- a/Treehouse/Treehouse/Network/Register/DTO/Request/PostRegisterFCMTokenRequestDTO.swift
+++ b/Treehouse/Treehouse/Network/Register/DTO/Request/PostRegisterFCMTokenRequestDTO.swift
@@ -1,0 +1,12 @@
+//
+//  PostRegisterFCMTokenRequestDTO.swift
+//  Treehouse
+//
+//  Created by ParkJunHyuk on 9/10/24.
+//
+
+import Foundation
+
+struct PostRegisterFCMTokenRequestDTO: Codable {
+    let fcmToken: String
+}

--- a/Treehouse/Treehouse/Network/Register/DTO/Request/PostRegisterPushAgreeRequestDTO.swift
+++ b/Treehouse/Treehouse/Network/Register/DTO/Request/PostRegisterPushAgreeRequestDTO.swift
@@ -1,0 +1,12 @@
+//
+//  PostRegisterPushAgreeRequestDTO.swift
+//  Treehouse
+//
+//  Created by ParkJunHyuk on 9/10/24.
+//
+
+import Foundation
+
+struct PostRegisterPushAgreeRequestDTO: Codable {
+    let pushAgree: Bool
+}

--- a/Treehouse/Treehouse/Network/Register/DTO/Response/PostRegisterFCMTokenResponseDTO.swift
+++ b/Treehouse/Treehouse/Network/Register/DTO/Response/PostRegisterFCMTokenResponseDTO.swift
@@ -1,0 +1,17 @@
+//
+//  PostRegisterFCMTokenResponseDTO.swift
+//  Treehouse
+//
+//  Created by ParkJunHyuk on 9/10/24.
+//
+
+import Foundation
+
+struct PostRegisterFCMTokenResponseDTO: Decodable {
+    let userId: Int
+    let saveFcmToken: Bool
+    
+    func toDomain() -> RegisterFCMTokenResponseEntity {
+        return RegisterFCMTokenResponseEntity(userId: userId, saveFcmToken: saveFcmToken)
+    }
+}

--- a/Treehouse/Treehouse/Network/Register/DTO/Response/PostRegisterPushAgreeResponseDTO.swift
+++ b/Treehouse/Treehouse/Network/Register/DTO/Response/PostRegisterPushAgreeResponseDTO.swift
@@ -1,0 +1,17 @@
+//
+//  PostRegisterPushAgreeResponseDTO.swift
+//  Treehouse
+//
+//  Created by ParkJunHyuk on 9/10/24.
+//
+
+import Foundation
+
+struct PostRegisterPushAgreeResponseDTO: Decodable {
+    let userId: Int
+    let pushAgree: Bool
+    
+    func toDomain() -> RegisterPushAgreeResponseEntity {
+        return RegisterPushAgreeResponseEntity(userId: userId, pushAgree: pushAgree)
+    }
+}

--- a/Treehouse/Treehouse/Network/Register/RegisterAPI.swift
+++ b/Treehouse/Treehouse/Network/Register/RegisterAPI.swift
@@ -14,6 +14,8 @@ enum RegisterAPI {
     case postReissueToken(requestBody: PostReissueTokenRequestDTO)
     case postCheckUserPhone(requestBody: PostCheckUserPhoneRequestDTO)
     case postExistsUserLogin(requestBody: PostExistsUserLoginRequestDTO)
+    case postRegisterFCMToken(requestBody: PostRegisterFCMTokenRequestDTO)
+    case postRegisterPushAgree(requestBody: PostRegisterPushAgreeRequestDTO)
     case deleteUser
 }
 
@@ -26,6 +28,8 @@ extension RegisterAPI: BaseRequest {
         case .postReissueToken: return "users/reissue"
         case .postCheckUserPhone: return "users/phone"
         case .postExistsUserLogin: return "users/login"
+        case .postRegisterFCMToken: return "users/fcm-token"
+        case .postRegisterPushAgree: return "users/push-agree"
         case .deleteUser: return "users/withdraw"
         }
     }
@@ -38,6 +42,8 @@ extension RegisterAPI: BaseRequest {
         case .postReissueToken: return .post
         case .postCheckUserPhone: return .post
         case .postExistsUserLogin: return .post
+        case .postRegisterFCMToken: return .post
+        case .postRegisterPushAgree: return .post
         case .deleteUser: return .delete
         }
     }
@@ -46,7 +52,7 @@ extension RegisterAPI: BaseRequest {
         switch self {
         case .postCheckUserName, .postRegisterUser, .postCheckUserPhone:
             return .noHeader
-        case .postRegisterTreeMember, .deleteUser:
+        case .postRegisterTreeMember, .postRegisterFCMToken, .postRegisterPushAgree, .deleteUser:
             return .accessTokenHeader
         case .postReissueToken:
             return .refreshTokenHeader
@@ -67,6 +73,8 @@ extension RegisterAPI: BaseRequest {
         case .postReissueToken(requestBody: let requestBody): return requestBody
         case .postCheckUserPhone(requestBody: let requestBody): return requestBody
         case .postExistsUserLogin(requestBody: let requestBody): return requestBody
+        case .postRegisterFCMToken(requestBody: let requestBody): return requestBody
+        case .postRegisterPushAgree(requestBody: let requestBody): return requestBody
         default: return .none
         }
     }

--- a/Treehouse/Treehouse/Network/Register/RegisterService.swift
+++ b/Treehouse/Treehouse/Network/Register/RegisterService.swift
@@ -89,6 +89,29 @@ class RegisterService {
         return try await networkServiceManager.performRequest(with: urlRequest, decodingType: PostExistsUserLoginResponseDTO.self)
     }
     
+    /// FCM 토큰을 유저 id 와 저장하는 API
+    func postRegisterFCMToken(token: String) async throws -> PostRegisterFCMTokenResponseDTO {
+        
+        let request = NetworkRequest(requestType: RegisterAPI.postRegisterFCMToken(requestBody: PostRegisterFCMTokenRequestDTO(fcmToken: token)))
+        
+        guard let urlRequest = request.request() else {
+            throw NetworkError.clientError(message: "Request 생성불가")
+        }
+        
+        return try await networkServiceManager.performRequest(with: urlRequest, decodingType: PostRegisterFCMTokenResponseDTO.self)
+    }
+    
+    /// 푸시 알림 동의 API
+    func postRegisterPushAgree(pushAgree: Bool) async throws -> PostRegisterPushAgreeResponseDTO {
+        let request = NetworkRequest(requestType: RegisterAPI.postRegisterPushAgree(requestBody: PostRegisterPushAgreeRequestDTO(pushAgree: pushAgree)))
+        
+        guard let urlRequest = request.request() else {
+            throw NetworkError.clientError(message: "Request 생성불가")
+        }
+        
+        return try await networkServiceManager.performRequest(with: urlRequest, decodingType: PostRegisterPushAgreeResponseDTO.self)
+    }
+    
     /// 회원탈퇴를 위한 API
     func deleteUser() async throws -> DeleteUserResponseDTO {
         let request = NetworkRequest(requestType: RegisterAPI.deleteUser)

--- a/Treehouse/Treehouse/Presentation/Auth/RegisterScene/ViewModels/FCMTokenViewModel.swift
+++ b/Treehouse/Treehouse/Presentation/Auth/RegisterScene/ViewModels/FCMTokenViewModel.swift
@@ -1,0 +1,52 @@
+//
+//  FCMTokenViewModel.swift
+//  Treehouse
+//
+//  Created by ParkJunHyuk on 9/10/24.
+//
+
+import Foundation
+import Observation
+
+@Observable
+final class FCMTokenViewModel: BaseViewModel {
+    
+    // MARK: - Property
+    
+    var isSaveFCMToken = false
+    var errorMessage: String?
+    
+    // MARK: - UseCase Property
+    
+    @ObservationIgnored
+    private let registerFCMTokenUseCase: PostRegisterFCMTokenUseCaseProtocol
+    
+    // MARK: - init
+    
+    init(registerFCMTokenUseCase: PostRegisterFCMTokenUseCaseProtocol) {
+        self.registerFCMTokenUseCase = registerFCMTokenUseCase
+        
+        print("FCMTokenViewModel Init")
+    }
+    
+    deinit {
+        print("Deinit FCMTokenViewModel")
+    }
+}
+
+extension FCMTokenViewModel {
+    func registerFCMToken() async {
+        let result = await registerFCMTokenUseCase.execute()
+        
+        switch result {
+        case .success(let response):
+            await MainActor.run {
+                isSaveFCMToken = response.saveFcmToken
+            }
+        case .failure(let error):
+            await MainActor.run {
+                self.errorMessage = error.localizedDescription
+            }
+        }
+    }
+}

--- a/Treehouse/Treehouse/Presentation/Auth/RegisterScene/ViewModels/RegisterPushNotiViewModel.swift
+++ b/Treehouse/Treehouse/Presentation/Auth/RegisterScene/ViewModels/RegisterPushNotiViewModel.swift
@@ -1,0 +1,82 @@
+//
+//  RegisterPushNotiViewModel.swift
+//  Treehouse
+//
+//  Created by ParkJunHyuk on 9/10/24.
+//
+
+import Foundation
+import Observation
+import UserNotifications
+
+@Observable
+final class RegisterPushNotiViewModel: BaseViewModel {
+    
+    // MARK: - Property
+    
+    var isPostPushAgree = false
+    var notificationStatus = false
+    var errorMessage: String?
+    
+    // MARK: - UseCase Property
+    
+    @ObservationIgnored
+    private let registerPushAgreeUseCase: PostRegisterPushAgreeUseCaseProtocol
+    
+    // MARK: - init
+    
+    init(registerPushAgreeUseCase: PostRegisterPushAgreeUseCaseProtocol) {
+        self.registerPushAgreeUseCase = registerPushAgreeUseCase
+        
+        checkNotificationStatus()
+        print("RegisterPushNotiViewModel Init")
+    }
+    
+    deinit {
+        print("Deinit RegisterPushNotiViewModel")
+    }
+    
+    func checkNotificationStatus() {
+        UNUserNotificationCenter.current().getNotificationSettings { settings in
+            DispatchQueue.main.async {
+                switch settings.authorizationStatus {
+                case .authorized:
+                    print("알림 허용됨")
+                    self.notificationStatus = true
+                case .denied:
+                    print("알림 거부됨")
+                    self.notificationStatus = false
+                case .notDetermined:
+                    print("알림 상태 미결정")
+                    self.notificationStatus = false
+                case .provisional:
+                    print("임시 알림 허용")
+                    self.notificationStatus = false
+                case .ephemeral:
+                    print("임시 세션 알림")
+                    self.notificationStatus = false
+                @unknown default:
+                    print("알 수 없는 상태")
+                    self.notificationStatus = false
+                }
+            }
+        }
+    }
+}
+
+extension RegisterPushNotiViewModel {
+    func registerPushAgree() async {
+        let result = await registerPushAgreeUseCase.execute(pushAgree: notificationStatus)
+        
+        switch result {
+        case .success(_):
+            await MainActor.run {
+                isPostPushAgree = true
+            }
+        case .failure(let error):
+            await MainActor.run {
+                self.errorMessage = error.localizedDescription
+            }
+        }
+    }
+}

--- a/Treehouse/Treehouse/Presentation/Auth/RegisterScene/ViewModels/UserSettingViewModel.swift
+++ b/Treehouse/Treehouse/Presentation/Auth/RegisterScene/ViewModels/UserSettingViewModel.swift
@@ -40,11 +40,7 @@ final class UserSettingViewModel: BaseViewModel {
     var phoneNumber: String?
     var treehouseId: Int?
 
-    var errorMessage: String? = nil {
-        didSet {
-            print(errorMessage)
-        }
-    }
+    var errorMessage: String?
     
     // MARK: - Invitation Property
     
@@ -310,7 +306,7 @@ extension UserSettingViewModel {
 extension UserSettingViewModel {
     func presignedURL() async -> Bool {
         
-        guard let treehouseId = treehouseId, 
+        guard let treehouseId = treehouseId,
                 let imageDataSize = profileImage?.getImageBitSize() else {
             print("treehouseId")
             return false

--- a/Treehouse/Treehouse/Presentation/Auth/RegisterScene/Views/LoginView.swift
+++ b/Treehouse/Treehouse/Presentation/Auth/RegisterScene/Views/LoginView.swift
@@ -16,8 +16,11 @@ struct LoginView: View {
     
     @State private var userLoginViewModel: UserLoginViewModel = UserLoginViewModel(existsUserLoginUseCase: ExistsUserLoginUserCase(repository: RegisterRepositoryImpl()), readMyProfileInfoUseCase: ReadMyProfileInfoUseCase(repository: MemberRepositoryImpl()))
     @State private var userInfoViewModel: UserInfoViewModel = UserInfoViewModel()
+    @State var fcmTokenViewModel = FCMTokenViewModel(registerFCMTokenUseCase: RegisterFCMTokenUseCase(repository: RegisterRepositoryImpl()))
+    @State var registerPushNotiViewModel = RegisterPushNotiViewModel(registerPushAgreeUseCase: RegisterPushAgreeUseCase(repository: RegisterRepositoryImpl()))
     
     @AppStorage(Config.loginKey) private var isLogin = false
+    @AppStorage("PushAgree") private var isPush = false
     
     // MARK: - View
     
@@ -58,7 +61,10 @@ struct LoginView: View {
                     if let userResult = result {
                         let userSaveResult = await userInfoViewModel.createData(newData: userResult)
                         
-                        if userLoginViewModel.isLogin && userSaveResult {
+                        await fcmTokenViewModel.registerFCMToken()
+                        await registerPushNotiViewModel.registerPushAgree()
+                        
+                        if userLoginViewModel.isLogin && userSaveResult && fcmTokenViewModel.isSaveFCMToken && registerPushNotiViewModel.isPostPushAgree {
                             isLogin = true
                             viewRouter.navigate(viewType: .enterTreehouse)
                         }

--- a/Treehouse/Treehouse/Presentation/Auth/RegisterScene/Views/ShowUserProfileView.swift
+++ b/Treehouse/Treehouse/Presentation/Auth/RegisterScene/Views/ShowUserProfileView.swift
@@ -14,6 +14,9 @@ struct ShowUserProfileView: View {
     @Environment(UserSettingViewModel.self) private var viewModel
     @Environment(ViewRouter.self) private var viewRouter
     
+    @State var fcmTokenViewModel = FCMTokenViewModel(registerFCMTokenUseCase: RegisterFCMTokenUseCase(repository: RegisterRepositoryImpl()))
+    @State var registerPushNotiViewModel = RegisterPushNotiViewModel(registerPushAgreeUseCase: RegisterPushAgreeUseCase(repository: RegisterRepositoryImpl()))
+    
     // MARK: - View
     
     var body: some View {
@@ -37,8 +40,10 @@ struct ShowUserProfileView: View {
             Button(action: {
                 Task {
                     let result = await viewModel.registerUser()
+                    await fcmTokenViewModel.registerFCMToken()
+                    await registerPushNotiViewModel.registerPushAgree()
                     
-                    if result {
+                    if result && fcmTokenViewModel.isSaveFCMToken && registerPushNotiViewModel.isPostPushAgree {
                         viewRouter.push(RegisterRouter.receivedFirstInvitationView)
                     }
                 }


### PR DESCRIPTION
## 📟 관련 이슈
- Resolved: #121 

<br>

## 👷 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
- FCM Token 을 저장하기 위한 API 구현
- Push 알람을 동의를 위한 API 구현
- Clean Architecture 를 위한 Usecase & Repository 구현
- 로그인 시 관련 API 로직 추가

<br>

## 🚨 참고 사항
<!-- 참고 사항을 적어주세요. 없으면 지워주세요. -->

### ` RegisterPushNotiViewModel ` - 유저의 알람 설정 관련 메서드 

``` swift
@Observable
final class RegisterPushNotiViewModel: BaseViewModel {
    func checkNotificationStatus() {
        UNUserNotificationCenter.current().getNotificationSettings { settings in
            DispatchQueue.main.async {
                switch settings.authorizationStatus {
                case .authorized:
                    print("알림 허용됨")
                    self.notificationStatus = true
                case .denied:
                    print("알림 거부됨")
                    self.notificationStatus = false
                case .notDetermined:
                    print("알림 상태 미결정")
                    self.notificationStatus = false
                case .provisional:
                    print("임시 알림 허용")
                    self.notificationStatus = false
                case .ephemeral:
                    print("임시 세션 알림")
                    self.notificationStatus = false
                @unknown default:
                    print("알 수 없는 상태")
                    self.notificationStatus = false
                }
            }
        }
    }
}
```

사용자의 알림 설정 상태를 체크할 수 있는 메서드 입니다.
settings 객체에는 알림 권한 상태를 갖고 있고 UI 업데이트가 필요할 가능성이 있기 때문에 메인스레드에서 해당 작업을 수행합니다. 
이렇게 각 상태를 전달 받아서 서버에 해당 유저의 알림 설정 상태를 보내게 됩니다.

<br>

## ✅ Checklist
- [X] 필요없는 주석, 프린트문 제거했는지 확인
- [X] 컨벤션 지켰는지 확인
