### PR TITLE
[Feat] #135 - 멤버 프로필에서 다른 트리 초대하기 로직 구현

### DIFF
--- a/Treehouse/Treehouse.xcodeproj/project.pbxproj
+++ b/Treehouse/Treehouse.xcodeproj/project.pbxproj
@@ -87,6 +87,8 @@
 		3F1BE13C2C214A9500D3AF1D /* AWSImageRepositoryProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F1BE13B2C214A9500D3AF1D /* AWSImageRepositoryProtocol.swift */; };
 		3F1BE13E2C21529000D3AF1D /* PutUploadImagesResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F1BE13D2C21529000D3AF1D /* PutUploadImagesResponseDTO.swift */; };
 		3F1BE1412C21741000D3AF1D /* PutUploadImagesResponseEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F1BE1402C21741000D3AF1D /* PutUploadImagesResponseEntity.swift */; };
+		3F25A3542C91C580006E2715 /* InvitationTreehouseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F25A3532C91C580006E2715 /* InvitationTreehouseView.swift */; };
+		3F25A3562C927FFA006E2715 /* InvitationTreehouseViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F25A3552C927FFA006E2715 /* InvitationTreehouseViewModel.swift */; };
 		3F2DB2792BCFF5FE00DEFBA6 /* ReceivedInvitationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F2DB2782BCFF5FE00DEFBA6 /* ReceivedInvitationView.swift */; };
 		3F2DB27B2BD0C83900DEFBA6 /* InvitationAlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F2DB27A2BD0C83900DEFBA6 /* InvitationAlertView.swift */; };
 		3F2DB27D2BD0F35900DEFBA6 /* InvitationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F2DB27C2BD0F35900DEFBA6 /* InvitationView.swift */; };
@@ -212,6 +214,8 @@
 		3FE944172BD645C300C3A869 /* ReceivedInvitationRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FE944162BD645C300C3A869 /* ReceivedInvitationRowView.swift */; };
 		3FEC57562C8F0BDD0080DF96 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3FEC57552C8F0BDD0080DF96 /* GoogleService-Info.plist */; };
 		3FEC575D2C8F0C2B0080DF96 /* Config.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 3FEC575C2C8F0C2B0080DF96 /* Config.xcconfig */; };
+		3FEC57612C8F23B80080DF96 /* TreeBranchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEC57602C8F23B80080DF96 /* TreeBranchViewModel.swift */; };
+		3FEC57632C8F28B80080DF96 /* MemberBranchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEC57622C8F28B80080DF96 /* MemberBranchView.swift */; };
 		3FEC57652C8F484F0080DF96 /* PostRegisterFCMTokenResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEC57642C8F484E0080DF96 /* PostRegisterFCMTokenResponseDTO.swift */; };
 		3FEC57672C8F48630080DF96 /* PostRegisterPushAgreeResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEC57662C8F48630080DF96 /* PostRegisterPushAgreeResponseDTO.swift */; };
 		3FEC57692C8F48770080DF96 /* PostRegisterFCMTokenRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEC57682C8F48770080DF96 /* PostRegisterFCMTokenRequestDTO.swift */; };
@@ -222,8 +226,6 @@
 		3FEC57732C8F499A0080DF96 /* RegisterPushAgreeResponseEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEC57722C8F499A0080DF96 /* RegisterPushAgreeResponseEntity.swift */; };
 		3FEC57752C8F49F60080DF96 /* FCMTokenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEC57742C8F49F60080DF96 /* FCMTokenViewModel.swift */; };
 		3FEC57772C8F4A080080DF96 /* RegisterPushNotiViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEC57762C8F4A080080DF96 /* RegisterPushNotiViewModel.swift */; };
-		3FEC57612C8F23B80080DF96 /* TreeBranchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEC57602C8F23B80080DF96 /* TreeBranchViewModel.swift */; };
-		3FEC57632C8F28B80080DF96 /* MemberBranchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEC57622C8F28B80080DF96 /* MemberBranchView.swift */; };
 		3FEEF75E2C69B27A002CBA53 /* ImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEEF75D2C69B27A002CBA53 /* ImageLoader.swift */; };
 		3FEEF7602C69F7B7002CBA53 /* ReadPageFeedPostUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEEF75F2C69F7B7002CBA53 /* ReadPageFeedPostUseCase.swift */; };
 		3FEEF7652C6DF7B0002CBA53 /* UINavigationController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEEF7642C6DF7B0002CBA53 /* UINavigationController+.swift */; };
@@ -400,6 +402,8 @@
 		3F1BE13B2C214A9500D3AF1D /* AWSImageRepositoryProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSImageRepositoryProtocol.swift; sourceTree = "<group>"; };
 		3F1BE13D2C21529000D3AF1D /* PutUploadImagesResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PutUploadImagesResponseDTO.swift; sourceTree = "<group>"; };
 		3F1BE1402C21741000D3AF1D /* PutUploadImagesResponseEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PutUploadImagesResponseEntity.swift; sourceTree = "<group>"; };
+		3F25A3532C91C580006E2715 /* InvitationTreehouseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvitationTreehouseView.swift; sourceTree = "<group>"; };
+		3F25A3552C927FFA006E2715 /* InvitationTreehouseViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvitationTreehouseViewModel.swift; sourceTree = "<group>"; };
 		3F2DB2782BCFF5FE00DEFBA6 /* ReceivedInvitationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceivedInvitationView.swift; sourceTree = "<group>"; };
 		3F2DB27A2BD0C83900DEFBA6 /* InvitationAlertView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvitationAlertView.swift; sourceTree = "<group>"; };
 		3F2DB27C2BD0F35900DEFBA6 /* InvitationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvitationView.swift; sourceTree = "<group>"; };
@@ -523,6 +527,8 @@
 		3FEC57552C8F0BDD0080DF96 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		3FEC575C2C8F0C2B0080DF96 /* Config.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
 		3FEC575E2C8F0C760080DF96 /* ci_post_clone.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = ci_post_clone.sh; sourceTree = "<group>"; };
+		3FEC57602C8F23B80080DF96 /* TreeBranchViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TreeBranchViewModel.swift; sourceTree = "<group>"; };
+		3FEC57622C8F28B80080DF96 /* MemberBranchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberBranchView.swift; sourceTree = "<group>"; };
 		3FEC57642C8F484E0080DF96 /* PostRegisterFCMTokenResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostRegisterFCMTokenResponseDTO.swift; sourceTree = "<group>"; };
 		3FEC57662C8F48630080DF96 /* PostRegisterPushAgreeResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostRegisterPushAgreeResponseDTO.swift; sourceTree = "<group>"; };
 		3FEC57682C8F48770080DF96 /* PostRegisterFCMTokenRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostRegisterFCMTokenRequestDTO.swift; sourceTree = "<group>"; };
@@ -533,8 +539,6 @@
 		3FEC57722C8F499A0080DF96 /* RegisterPushAgreeResponseEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterPushAgreeResponseEntity.swift; sourceTree = "<group>"; };
 		3FEC57742C8F49F60080DF96 /* FCMTokenViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FCMTokenViewModel.swift; sourceTree = "<group>"; };
 		3FEC57762C8F4A080080DF96 /* RegisterPushNotiViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterPushNotiViewModel.swift; sourceTree = "<group>"; };
-		3FEC57602C8F23B80080DF96 /* TreeBranchViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TreeBranchViewModel.swift; sourceTree = "<group>"; };
-		3FEC57622C8F28B80080DF96 /* MemberBranchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberBranchView.swift; sourceTree = "<group>"; };
 		3FEEF75D2C69B27A002CBA53 /* ImageLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageLoader.swift; sourceTree = "<group>"; };
 		3FEEF75F2C69F7B7002CBA53 /* ReadPageFeedPostUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadPageFeedPostUseCase.swift; sourceTree = "<group>"; };
 		3FEEF7642C6DF7B0002CBA53 /* UINavigationController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UINavigationController+.swift"; sourceTree = "<group>"; };
@@ -1183,6 +1187,7 @@
 				3F8AE7072C59FD6B00E999C4 /* PresingedURLViewModel.swift */,
 				3F8AE7092C5A01C200E999C4 /* LoadImageAWSViewModel.swift */,
 				3F8AE7172C5B1D6F00E999C4 /* CurrentTreehouseInfoViewModel.swift */,
+				3F25A3552C927FFA006E2715 /* InvitationTreehouseViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -1371,6 +1376,7 @@
 				3F8530E92C5281E5003FA07A /* CustomAsyncImage.swift */,
 				3F6801CC2C5FC065005E694E /* CustomAlertView.swift */,
 				3FA541542C60F06200723BAD /* LottieView.swift */,
+				3F25A3532C91C580006E2715 /* InvitationTreehouseView.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -2268,9 +2274,11 @@
 				3F8846002BF095F60021FB79 /* UserSettingViewModel.swift in Sources */,
 				3F5150542C0EC46100AD05C3 /* InvitationRepositoryImpl.swift in Sources */,
 				3FF106FE2BEA079500C52908 /* HttpMethod.swift in Sources */,
+				3F25A3542C91C580006E2715 /* InvitationTreehouseView.swift in Sources */,
 				3F1BE1322C211D0200D3AF1D /* AWSImageRepositoryImpl.swift in Sources */,
 				3F81719B2C46D18D00CEE21E /* EmojiViewModel.swift in Sources */,
 				00C2F5672C15B5560009C6A1 /* SettingView.swift in Sources */,
+				3F25A3562C927FFA006E2715 /* InvitationTreehouseViewModel.swift in Sources */,
 				3F7F25EA2C8808F400863E3D /* DIContainer.swift in Sources */,
 				3FF490042C50FD0600A6DD8A /* TreehouseRepositoryProtocol.swift in Sources */,
 				00B591952C23549400F7C38C /* ChecklAvailableInvitationUseCase.swift in Sources */,

--- a/Treehouse/Treehouse/Domain/Entities/Member/ReadMemberInfoResponseEntity.swift
+++ b/Treehouse/Treehouse/Domain/Entities/Member/ReadMemberInfoResponseEntity.swift
@@ -11,6 +11,7 @@ struct ReadMemberInfoResponseEntity: Decodable {
     let memberId: Int
     let memberName: String
     let userName: String
+    let phone: String
     let closestMemberCount: Int
     let treehouseCount: Int
     let fromMe: Int

--- a/Treehouse/Treehouse/Global/Components/CustomAsyncImage.swift
+++ b/Treehouse/Treehouse/Global/Components/CustomAsyncImage.swift
@@ -45,7 +45,16 @@ struct CustomAsyncImage: View {
         Group {
             switch imageLoader.state {
             case .loading:
-                ProgressView()
+                switch type {
+                case .memberProfileImage, .postMemberProfileImage:
+                    Circle()
+                        .fill(.gray3)
+                case .postImage:
+                    RoundedRectangle(cornerRadius: 6.0)
+                        .fill(.gray3)
+                default:
+                    ProgressView()
+                }
                     
             case .success(let image):
                 Image(uiImage: image)
@@ -80,9 +89,9 @@ struct CustomAsyncImage: View {
                 .resizable()
                 .scaledToFit()
         case .postImage:
-            Image(.imgDummy)
-                .resizable()
-                .scaledToFit()
+            RoundedRectangle(cornerRadius: 6.0)
+                .fill(.gray3)
+
         case .treehouseImage, .postTreehouseImage:
             Image(.imgGroup)
                 .resizable()

--- a/Treehouse/Treehouse/Global/Components/InvitationTreehouseView.swift
+++ b/Treehouse/Treehouse/Global/Components/InvitationTreehouseView.swift
@@ -17,6 +17,8 @@ struct InvitationTreehouseView: View {
                                                                            checkAvailableInvitationUseCase: CheckAvailableInvitationUseCase(repository: InvitationRepositoryImpl()),
                                                                            invitationUseCase: InvitationUseCase(repository: InvitationRepositoryImpl()))
     @AppStorage("treehouseId") private var selectedTreehouseId: Int = -1
+    
+    @Binding var showSheet: Bool
 
     // MARK: - View
     
@@ -75,6 +77,12 @@ struct InvitationTreehouseView: View {
             Button(action: {
                 Task {
                     await invitationTreehouseViewModel.invitationTreehouse()
+                    
+                    await MainActor.run {
+                        if invitationTreehouseViewModel.invitationResult == true {
+                            showSheet.toggle()
+                        }
+                    }
                 }
             }) {
                 Text(StringLiterals.Invitation.buttonTitle2)
@@ -95,7 +103,7 @@ struct InvitationTreehouseView: View {
         .onAppear {
             invitationTreehouseViewModel.senderId = userInfoViewModel.userInfo?.findTreehouse(id: selectedTreehouseId)?.treehouseMemberId
             
-//            invitationTreehouseViewModel.memberPhoenNumber = memberProfileViewModel.memberProfileData.
+            invitationTreehouseViewModel.memberPhoenNumber = memberProfileViewModel.memberProfileData?.phone
         }
     }
 }
@@ -138,7 +146,7 @@ extension InvitationTreehouseView {
 }
 
 #Preview {
-    InvitationTreehouseView()
+    InvitationTreehouseView(showSheet: .constant(false))
         .environment(MemberProfileViewModel(
             readMemberInfoUseCase: ReadMemberInfoUseCase(repository: MemberRepositoryImpl()),
             readMemberFeedUseCase: ReadMemberFeedUseCase(repository: MemberRepositoryImpl()),

--- a/Treehouse/Treehouse/Global/Components/InvitationTreehouseView.swift
+++ b/Treehouse/Treehouse/Global/Components/InvitationTreehouseView.swift
@@ -1,0 +1,148 @@
+//
+//  InvitationTreehouseView.swift
+//  Treehouse
+//
+//  Created by ParkJunHyuk on 9/11/24.
+//
+
+import SwiftUI
+
+struct InvitationTreehouseView: View {
+    
+    // MARK: - State Property
+    
+    @Environment(MemberProfileViewModel.self) var memberProfileViewModel
+    @State private var userInfoViewModel = UserInfoViewModel()
+    @State var invitationTreehouseViewModel = InvitationTreehouseViewModel(readMyTreehouseInfoUseCase: ReadMyTreehouseInfoUseCase(repository: TreehouseRepositoryImpl()),
+                                                                           checkAvailableInvitationUseCase: CheckAvailableInvitationUseCase(repository: InvitationRepositoryImpl()),
+                                                                           invitationUseCase: InvitationUseCase(repository: InvitationRepositoryImpl()))
+    @AppStorage("treehouseId") private var selectedTreehouseId: Int = -1
+
+    // MARK: - View
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Capsule()
+                .fill(.gray4)
+                .frame(width: SizeLiterals.Screen.screenWidth * 50 / 393, height: 4, alignment: .center)
+                .padding(.bottom, 24)
+                .frame(maxWidth: .infinity, alignment: .center)
+            
+            memberTitleView
+                .padding(.bottom, SizeLiterals.Screen.screenHeight * 24 / 852)
+            
+            invitationSectionView
+                .padding(.bottom, SizeLiterals.Screen.screenHeight * 9 / 852)
+            
+            HStack(spacing: 27) {
+                ZStack(alignment: .leading) {
+                    RoundedRectangle(cornerRadius: 16)
+                        .fill(.gray2)
+                        .frame(width: SizeLiterals.Screen.screenWidth * 292/393)
+                        .frame(height: 10)
+                    
+                    RoundedRectangle(cornerRadius: 16)
+                        .fill(.treeBlack)
+                        .frame(width: CGFloat(invitationTreehouseViewModel.activeRate)/100 * SizeLiterals.Screen.screenWidth * 292/393)
+                        .frame(height: 10)
+                }
+                
+                Image(.icInvitation)
+            }
+            .padding(.bottom, 28)
+                
+            Text(StringLiterals.MemberProfile.bottomSheetLabel2)
+                .fontWithLineHeight(fontLevel: .heading4)
+                .foregroundStyle(.treeBlack)
+                .padding(.bottom, 14)
+            
+            List(invitationTreehouseViewModel.treehouseInfo ?? []) { data in
+                Button(action: {
+                    invitationTreehouseViewModel.invitationTreehouseTapped(treehouseId: data.treehouseId)
+                }) {
+                    TreehouseInfoRow(treehouseImageUrl: data.treehouseImageUrl ?? "",
+                                     treehouseName: data.treehouseName,
+                                     treehouseSize: data.treehouseSize,
+                                     currentTreeHouse: data.currentTreeHouse
+                    )
+                }
+                .buttonStyle(PlainButtonStyle())
+                .listRowInsets(EdgeInsets(top: 7, leading: 2, bottom: 7, trailing: 2))
+                .listRowSeparator(.hidden)
+            }
+            .listStyle(PlainListStyle())
+            
+            Button(action: {
+                Task {
+                    await invitationTreehouseViewModel.invitationTreehouse()
+                }
+            }) {
+                Text(StringLiterals.Invitation.buttonTitle2)
+                    .fontWithLineHeight(fontLevel: .body2)
+                    .foregroundStyle(invitationTreehouseViewModel.isSelectTreehouse ? .grayscaleWhite : .gray6)
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 56)
+                    .background(invitationTreehouseViewModel.isSelectTreehouse ? .grayscaleBlack : .gray2)
+                    .cornerRadius(10)
+            }
+        }
+        .padding(.top, 10)
+        .padding(.horizontal, 16)
+        .padding(.bottom, 29)
+        .task {
+            await invitationTreehouseViewModel.performAsyncTasks(currentTreehouseId: selectedTreehouseId)
+        }
+        .onAppear {
+            invitationTreehouseViewModel.senderId = userInfoViewModel.userInfo?.findTreehouse(id: selectedTreehouseId)?.treehouseMemberId
+            
+//            invitationTreehouseViewModel.memberPhoenNumber = memberProfileViewModel.memberProfileData.
+        }
+    }
+}
+
+extension InvitationTreehouseView {
+    @ViewBuilder
+    var memberTitleView: some View {
+        HStack(spacing: 0) {
+            CustomAsyncImage(url: memberProfileViewModel.memberProfileData?.profileImageUrl ?? "",
+                             type: .postMemberProfileImage,
+                             width: 36,
+                             height: 36)
+            .clipShape(Circle())
+            .padding(.trailing, 10)
+            
+            Text(memberProfileViewModel.memberProfileData?.memberName ?? "")
+                .fontWithLineHeight(fontLevel: .body2)
+                .foregroundStyle(.treeBlack)
+                .padding(.trailing, 6)
+            
+            Text("초대하기")
+                .fontWithLineHeight(fontLevel: .body3)
+                .foregroundStyle(.treeBlack)
+        }
+    }
+    
+    @ViewBuilder
+    var invitationSectionView: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text("가진 초대장 : \(invitationTreehouseViewModel.availableInvitation)개")
+                .fontWithLineHeight(fontLevel: .heading4)
+                .foregroundStyle(.treeBlack)
+                .padding(.bottom, 6)
+            
+            Text(StringLiterals.Invitation.guidanceTitle1)
+                .fontWithLineHeight(fontLevel: .body3)
+                .foregroundStyle(.gray6)
+        }
+    }
+}
+
+#Preview {
+    InvitationTreehouseView()
+        .environment(MemberProfileViewModel(
+            readMemberInfoUseCase: ReadMemberInfoUseCase(repository: MemberRepositoryImpl()),
+            readMemberFeedUseCase: ReadMemberFeedUseCase(repository: MemberRepositoryImpl()),
+            treehouseId: 0,
+            memberId: 0
+        ))
+}

--- a/Treehouse/Treehouse/Global/ViewModel/InvitationTreehouseViewModel.swift
+++ b/Treehouse/Treehouse/Global/ViewModel/InvitationTreehouseViewModel.swift
@@ -1,0 +1,152 @@
+//
+//  InvitationTreehouseViewModel.swift
+//  Treehouse
+//
+//  Created by ParkJunHyuk on 9/12/24.
+//
+
+import Foundation
+import Observation
+
+@Observable
+final class InvitationTreehouseViewModel: BaseViewModel {
+    
+    // MARK: - Property
+    
+    var treehouseInfo: [ReadTreehouseInfoResponseEntity]?
+    var availableInvitation: Int = 0
+    var activeRate: Int = 0
+    var isSelectTreehouse: Bool = false {
+        didSet {
+            if isSelectTreehouse == false {
+                self.selectedTreehouseId = nil
+            }
+        }
+    }
+    var errorMessage: String = ""
+    
+    @ObservationIgnored
+    var senderId: Int?
+    
+    @ObservationIgnored
+    var memberPhoenNumber: String?
+    
+    @ObservationIgnored
+    var selectedTreehouseId: Int?
+    
+    // MARK: - UseCase Property
+    
+    @ObservationIgnored
+    private let readMyTreehouseInfoUseCase: GetReadMyTreehouseInfoUseCaseProtocol
+    
+    @ObservationIgnored
+    private let checkAvailableInvitationUseCase: GetCheckAvailableInvitationUseCaseProtocol
+    
+    @ObservationIgnored
+    private let invitationUseCase: PostInvitationUseCaseProtocol
+    
+    init(readMyTreehouseInfoUseCase: GetReadMyTreehouseInfoUseCaseProtocol,
+         checkAvailableInvitationUseCase: GetCheckAvailableInvitationUseCaseProtocol,
+         invitationUseCase: PostInvitationUseCaseProtocol) {
+        self.readMyTreehouseInfoUseCase = readMyTreehouseInfoUseCase
+        self.checkAvailableInvitationUseCase = checkAvailableInvitationUseCase
+        self.invitationUseCase = invitationUseCase
+        
+        print("init InvitationTreehouseViewModel")
+    }
+    
+    deinit {
+        print("Deinit InvitationTreehouseViewModel")
+    }
+    
+    func invitationTreehouseTapped(treehouseId: Int) {
+        guard treehouseInfo != nil else { return }
+        
+        findSelectedTreehouse(treehouseId)
+
+        if let findTreehouseIndex = treehouseInfo?.firstIndex(where: { $0.treehouseId == treehouseId }) {
+            
+            if treehouseInfo?[findTreehouseIndex].currentTreeHouse == false {
+                treehouseInfo?[findTreehouseIndex].currentTreeHouse = true
+                isSelectTreehouse = true
+                selectedTreehouseId = treehouseId
+            } else {
+                treehouseInfo?[findTreehouseIndex].currentTreeHouse = false
+                isSelectTreehouse = false
+            }
+        } else {
+            isSelectTreehouse = false
+        }
+    }
+    
+    /// 이미 선택된 Treehouse 가 존재하면 false 로 변경하는 메서드
+    private func findSelectedTreehouse(_ treehouseId: Int) {
+        if let selectedIndex = treehouseInfo?.firstIndex(where: { $0.currentTreeHouse == true }) {
+            
+            if treehouseInfo?[selectedIndex].treehouseId != treehouseId {
+                treehouseInfo?[selectedIndex].currentTreeHouse = false
+            }
+        }
+    }
+}
+
+// MARK: - Treehouse API Extension
+
+extension InvitationTreehouseViewModel {
+    func performAsyncTasks(currentTreehouseId: Int) async {
+        // 비동기 작업을 순차적으로 호출
+        await readMyTreehouseInfo(currentTreehouseId: currentTreehouseId)
+        await checkAvailableInvitation()
+    }
+    
+    /// 내 트리하우스를 조회하는 API
+    func readMyTreehouseInfo(currentTreehouseId: Int) async {
+        let result = await readMyTreehouseInfoUseCase.execute()
+        
+        switch result {
+        case .success(let response):
+            treehouseInfo = response.treeohouses
+  
+        case .failure(let error):
+            await MainActor.run {
+                self.errorMessage = error.localizedDescription
+                print(errorMessage)
+            }
+        }
+    }
+    
+    func checkAvailableInvitation() async {
+        let result = await checkAvailableInvitationUseCase.execute()
+        
+        switch result {
+        case .success(let response):
+            await MainActor.run {
+                availableInvitation = response.availableInvitation
+                activeRate = response.activeRate
+            }
+        case .failure(let error):
+            await MainActor.run {
+                self.errorMessage = error.localizedDescription
+            }
+        }
+    }
+    
+    func invitationTreehouse() async -> Bool {
+        guard let senderId = senderId, let memberPhoenNumber = memberPhoenNumber, let selectedTreehouseId = selectedTreehouseId else {
+            return false
+        }
+        
+        let result = await invitationUseCase.execute(senderId: senderId, phoneNumber: memberPhoenNumber, treehouseId: selectedTreehouseId)
+        
+        switch result {
+        case .success(_):
+            return true
+        case .failure(let error):
+            await MainActor.run {
+                self.errorMessage = error.localizedDescription
+            }
+            
+            return false
+        }
+    }
+}

--- a/Treehouse/Treehouse/Global/ViewModel/InvitationTreehouseViewModel.swift
+++ b/Treehouse/Treehouse/Global/ViewModel/InvitationTreehouseViewModel.swift
@@ -16,6 +16,7 @@ final class InvitationTreehouseViewModel: BaseViewModel {
     var treehouseInfo: [ReadTreehouseInfoResponseEntity]?
     var availableInvitation: Int = 0
     var activeRate: Int = 0
+    var invitationResult = false
     var isSelectTreehouse: Bool = false {
         didSet {
             if isSelectTreehouse == false {
@@ -131,22 +132,20 @@ extension InvitationTreehouseViewModel {
         }
     }
     
-    func invitationTreehouse() async -> Bool {
+    func invitationTreehouse() async {
         guard let senderId = senderId, let memberPhoenNumber = memberPhoenNumber, let selectedTreehouseId = selectedTreehouseId else {
-            return false
+            return
         }
         
         let result = await invitationUseCase.execute(senderId: senderId, phoneNumber: memberPhoenNumber, treehouseId: selectedTreehouseId)
         
         switch result {
         case .success(_):
-            return true
+            invitationResult = true
         case .failure(let error):
             await MainActor.run {
                 self.errorMessage = error.localizedDescription
             }
-            
-            return false
         }
     }
 }

--- a/Treehouse/Treehouse/Global/ViewModel/MemberProfileViewModel.swift
+++ b/Treehouse/Treehouse/Global/ViewModel/MemberProfileViewModel.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-
 import Observation
 
 @Observable

--- a/Treehouse/Treehouse/Network/Member/DTO/Response/GetReadMemberInfoResponseDTO.swift
+++ b/Treehouse/Treehouse/Network/Member/DTO/Response/GetReadMemberInfoResponseDTO.swift
@@ -11,6 +11,7 @@ struct GetReadMemberInfoResponseDTO: Decodable {
     let memberId: Int
     let memberName: String
     let userName: String
+    let phone: String
     let closestMemberCount: Int
     let treehouseCount: Int
     let fromMe: Int
@@ -22,6 +23,7 @@ struct GetReadMemberInfoResponseDTO: Decodable {
             memberId: memberId,
             memberName: memberName,
             userName: userName,
+            phone: phone,
             closestMemberCount: closestMemberCount,
             treehouseCount: treehouseCount,
             fromMe: fromMe,

--- a/Treehouse/Treehouse/Presentation/Auth/RegisterScene/ViewModels/UserSettingViewModel.swift
+++ b/Treehouse/Treehouse/Presentation/Auth/RegisterScene/ViewModels/UserSettingViewModel.swift
@@ -375,6 +375,7 @@ extension UserSettingViewModel {
             }
         } catch let error as NSError {
             await MainActor.run {
+                print(error.userInfo)
                 errorMessage = "인증 실패: \(error.localizedDescription)"
             }
         }

--- a/Treehouse/Treehouse/Presentation/Feed/FeedScene/Views/PostDetailView.swift
+++ b/Treehouse/Treehouse/Presentation/Feed/FeedScene/Views/PostDetailView.swift
@@ -39,7 +39,7 @@ struct PostDetailView: View {
         ZStack {
             VStack(spacing: 0) {
                 ScrollView {
-                    if let postId = feedViewModel.currentPostId, let postDetailData = postDetailViewModel.detailFeedListData {
+                    if let _ = feedViewModel.currentPostId, let postDetailData = postDetailViewModel.detailFeedListData {
                     
                         VStack {
                             SinglePostView(sentTime: postDetailData.postedAt,
@@ -55,12 +55,6 @@ struct PostDetailView: View {
                                 .environment(emojiViewModel)
                                 .environment(commentViewModel)
                         }
-                    } else {
-                        SinglePostView(sentTime: "",
-                                       postContent: "정보없음",
-                                       postImageURLs: [""],
-                                       memberProfile: MemberProfileEntity(memberId: 0, memberName: "", memberProfileImageUrl: "", memberBranch: 0),
-                                       postType: .DetailView)
                     }
                     
                     Divider()

--- a/Treehouse/Treehouse/Presentation/Profile/Views/MemberProfileView.swift
+++ b/Treehouse/Treehouse/Presentation/Profile/Views/MemberProfileView.swift
@@ -61,17 +61,22 @@ struct MemberProfileView: View {
                                         .onAppear {
                                             feedViewModel.currentPostId = feed.postId
                                         }
-                                    
-                                    CommentCountView(commentCount: feed.commentCount)
-                                        .padding(.top, 10)
-                                        .padding(.trailing, 16)
-                                        .onTapGesture {
-                                            feedViewModel.currentPostId = feed.postId
-                                            viewRouter.push(FeedRouter.postDetailView)
-                                        }
+                                    if feed.commentCount > 0 {
+                                        CommentCountView(commentCount: feed.commentCount)
+                                            .padding(.top, 10)
+                                            .padding(.trailing, 16)
+                                            .onTapGesture {
+                                                feedViewModel.currentPostId = feed.postId
+                                                viewRouter.push(FeedRouter.postDetailView)
+                                            }
+                                    }
                                 }
                                 .padding(.leading, 62)
                                 .padding(.bottom, 16)
+                                
+                                Rectangle()
+                                    .frame(maxWidth: .infinity, maxHeight: 1)
+                                    .foregroundColor(.gray3)
                             }
                             .background(
                                 Color.clear
@@ -90,10 +95,9 @@ struct MemberProfileView: View {
             }
         }
         .sheet(isPresented: $showSheet) {
-//            InvitationTreehouseView(memberName: memberProfileViewModel.memberProfileData?.memberName ?? "정보없음",
-//                                    memberProfileUrl: memberProfileViewModel.memberProfileData?.profileImageUrl ?? "")
-//            .environment(memberProfileViewModel)
-//                .presentationDetents([.large])
+            InvitationTreehouseView(showSheet: $showSheet)
+                .environment(memberProfileViewModel)
+                .presentationDetents([.large])
         }
         .navigationTitle(memberProfileViewModel.title)
         .navigationBarTitleDisplayMode(.inline)

--- a/Treehouse/Treehouse/Presentation/Profile/Views/MemberProfileView.swift
+++ b/Treehouse/Treehouse/Presentation/Profile/Views/MemberProfileView.swift
@@ -19,6 +19,7 @@ struct MemberProfileView: View {
     
     @State var isPresent = false
     @State var isLoading = true
+    @State private var showSheet = false
     
     // MARK: - View
     
@@ -35,7 +36,7 @@ struct MemberProfileView: View {
                                      branchCount: data.closestMemberCount,
                                      treeHouseCount: data.treehouseCount,
                                      root: "\(data.fromMe)",
-                                     inviteAction: nil,
+                                     inviteAction: { showSheet = true },
                                      branchAction: { viewRouter.push(ProfileRouter.memberBranchView(treehouseId: feedViewModel.currentTreehouseId ?? 0, memberId: data.memberId))
                                     },
                                      profileAction: nil)
@@ -88,8 +89,15 @@ struct MemberProfileView: View {
                 await memberProfileViewModel.performAsyncTasks()
             }
         }
+        .sheet(isPresented: $showSheet) {
+//            InvitationTreehouseView(memberName: memberProfileViewModel.memberProfileData?.memberName ?? "정보없음",
+//                                    memberProfileUrl: memberProfileViewModel.memberProfileData?.profileImageUrl ?? "")
+//            .environment(memberProfileViewModel)
+//                .presentationDetents([.large])
+        }
         .navigationTitle(memberProfileViewModel.title)
         .navigationBarTitleDisplayMode(.inline)
+        .background(.grayscaleWhite)
         .task {
             await memberProfileViewModel.performAsyncTasks()
         }
@@ -109,6 +117,7 @@ struct MemberProfileView: View {
             )
         )
         .environment(ViewRouter())
+        .environment(FeedViewModel(getReadTreehouseInfoUseCase: ReadTreehouseInfoUseCase(repository: TreehouseRepositoryImpl())))
     }
 }
 


### PR DESCRIPTION
## 📟 관련 이슈
- Resolved: #135 

## 👷 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
- MemberProfile 에서 다른 Treehouse 초대하기 로직 구현
- PostDetailView 로 이동 시 생기는 스켈레톤 UI 수정
- GetReadMemberInfoResponseDTO & GetReadMemberInfoResponseEntity 에 Phone 프로퍼티 추가

<br>

## 📸 스크린샷
|기능|스켈레톤 UI 변경 전|스켈레톤 UI 변경 후|
|:--:|:--:|:--:|
|GIF|<img src = "https://github.com/user-attachments/assets/f5c3b566-444d-4a32-8381-725a92cbcad0" width ="250">|<img src = "https://github.com/user-attachments/assets/c94fa9a2-1b17-498a-89fe-2ad0702e95a9" width ="250">|

- 다른 Treehouse 로 초대하기

https://github.com/user-attachments/assets/30d90005-e8a4-448a-8649-c7d8ef31c131

<br>

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
