### PR TITLE
[Feat] #133 - Treehouse 설립자의 멤버 가입 오류를 위한 새로운 API 연결

### DIFF
--- a/Treehouse/Treehouse.xcodeproj/project.pbxproj
+++ b/Treehouse/Treehouse.xcodeproj/project.pbxproj
@@ -212,6 +212,8 @@
 		3FE944172BD645C300C3A869 /* ReceivedInvitationRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FE944162BD645C300C3A869 /* ReceivedInvitationRowView.swift */; };
 		3FEC57562C8F0BDD0080DF96 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3FEC57552C8F0BDD0080DF96 /* GoogleService-Info.plist */; };
 		3FEC575D2C8F0C2B0080DF96 /* Config.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 3FEC575C2C8F0C2B0080DF96 /* Config.xcconfig */; };
+		3FEC57612C8F23B80080DF96 /* TreeBranchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEC57602C8F23B80080DF96 /* TreeBranchViewModel.swift */; };
+		3FEC57632C8F28B80080DF96 /* MemberBranchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEC57622C8F28B80080DF96 /* MemberBranchView.swift */; };
 		3FEC57652C8F484F0080DF96 /* PostRegisterFCMTokenResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEC57642C8F484E0080DF96 /* PostRegisterFCMTokenResponseDTO.swift */; };
 		3FEC57672C8F48630080DF96 /* PostRegisterPushAgreeResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEC57662C8F48630080DF96 /* PostRegisterPushAgreeResponseDTO.swift */; };
 		3FEC57692C8F48770080DF96 /* PostRegisterFCMTokenRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEC57682C8F48770080DF96 /* PostRegisterFCMTokenRequestDTO.swift */; };
@@ -222,8 +224,6 @@
 		3FEC57732C8F499A0080DF96 /* RegisterPushAgreeResponseEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEC57722C8F499A0080DF96 /* RegisterPushAgreeResponseEntity.swift */; };
 		3FEC57752C8F49F60080DF96 /* FCMTokenViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEC57742C8F49F60080DF96 /* FCMTokenViewModel.swift */; };
 		3FEC57772C8F4A080080DF96 /* RegisterPushNotiViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEC57762C8F4A080080DF96 /* RegisterPushNotiViewModel.swift */; };
-		3FEC57612C8F23B80080DF96 /* TreeBranchViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEC57602C8F23B80080DF96 /* TreeBranchViewModel.swift */; };
-		3FEC57632C8F28B80080DF96 /* MemberBranchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEC57622C8F28B80080DF96 /* MemberBranchView.swift */; };
 		3FEEF75E2C69B27A002CBA53 /* ImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEEF75D2C69B27A002CBA53 /* ImageLoader.swift */; };
 		3FEEF7602C69F7B7002CBA53 /* ReadPageFeedPostUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEEF75F2C69F7B7002CBA53 /* ReadPageFeedPostUseCase.swift */; };
 		3FEEF7652C6DF7B0002CBA53 /* UINavigationController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEEF7642C6DF7B0002CBA53 /* UINavigationController+.swift */; };
@@ -523,6 +523,8 @@
 		3FEC57552C8F0BDD0080DF96 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		3FEC575C2C8F0C2B0080DF96 /* Config.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
 		3FEC575E2C8F0C760080DF96 /* ci_post_clone.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = ci_post_clone.sh; sourceTree = "<group>"; };
+		3FEC57602C8F23B80080DF96 /* TreeBranchViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TreeBranchViewModel.swift; sourceTree = "<group>"; };
+		3FEC57622C8F28B80080DF96 /* MemberBranchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberBranchView.swift; sourceTree = "<group>"; };
 		3FEC57642C8F484E0080DF96 /* PostRegisterFCMTokenResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostRegisterFCMTokenResponseDTO.swift; sourceTree = "<group>"; };
 		3FEC57662C8F48630080DF96 /* PostRegisterPushAgreeResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostRegisterPushAgreeResponseDTO.swift; sourceTree = "<group>"; };
 		3FEC57682C8F48770080DF96 /* PostRegisterFCMTokenRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostRegisterFCMTokenRequestDTO.swift; sourceTree = "<group>"; };
@@ -533,8 +535,6 @@
 		3FEC57722C8F499A0080DF96 /* RegisterPushAgreeResponseEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterPushAgreeResponseEntity.swift; sourceTree = "<group>"; };
 		3FEC57742C8F49F60080DF96 /* FCMTokenViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FCMTokenViewModel.swift; sourceTree = "<group>"; };
 		3FEC57762C8F4A080080DF96 /* RegisterPushNotiViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterPushNotiViewModel.swift; sourceTree = "<group>"; };
-		3FEC57602C8F23B80080DF96 /* TreeBranchViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TreeBranchViewModel.swift; sourceTree = "<group>"; };
-		3FEC57622C8F28B80080DF96 /* MemberBranchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberBranchView.swift; sourceTree = "<group>"; };
 		3FEEF75D2C69B27A002CBA53 /* ImageLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageLoader.swift; sourceTree = "<group>"; };
 		3FEEF75F2C69F7B7002CBA53 /* ReadPageFeedPostUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadPageFeedPostUseCase.swift; sourceTree = "<group>"; };
 		3FEEF7642C6DF7B0002CBA53 /* UINavigationController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UINavigationController+.swift"; sourceTree = "<group>"; };

--- a/Treehouse/Treehouse/Data/Repositories/RegisterRepositoryImpl.swift
+++ b/Treehouse/Treehouse/Data/Repositories/RegisterRepositoryImpl.swift
@@ -30,9 +30,9 @@ final class RegisterRepositoryImpl: RegisterRepositoryProtocol {
         }
     }
     
-    func postRegisterTreeMember(requestDTO: PostRegisterTreeMemberRequestDTO) async -> Result<RegisterTreeMemberResponseEntity, NetworkError> {
+    func postRegisterTreeMember(registerType: RegisterType, requestDTO: PostRegisterTreeMemberRequestDTO) async -> Result<RegisterTreeMemberResponseEntity, NetworkError> {
         do {
-            let response = try await registerService.postRegisterTreeMember(requestBody: requestDTO)
+            let response = try await registerService.postRegisterTreeMember(registerType: registerType, requestBody: requestDTO)
             return .success(response.toDomain())
         } catch let error as NetworkError {
             return .failure(error)

--- a/Treehouse/Treehouse/Domain/RepositoryProtocol/RegisterRepositoryProtocol.swift
+++ b/Treehouse/Treehouse/Domain/RepositoryProtocol/RegisterRepositoryProtocol.swift
@@ -10,7 +10,7 @@ import Foundation
 protocol RegisterRepositoryProtocol {
     func postCheckName(userName: String) async throws -> CheckNameResponseEntity
     func postRegisterUser(phoneNumber: String, userName: String) async -> Result<RegisterUserResponseEntity, NetworkError>
-    func postRegisterTreeMember(requestDTO: PostRegisterTreeMemberRequestDTO) async -> Result<RegisterTreeMemberResponseEntity, NetworkError>
+    func postRegisterTreeMember(registerType: RegisterType, requestDTO: PostRegisterTreeMemberRequestDTO) async -> Result<RegisterTreeMemberResponseEntity, NetworkError>
     func postCheckUserPhone(phoneNumber: String) async -> Result<CheckUserPhoneResponseEntity, NetworkError>
     func postExistsUserLogin(phoneNumber: String) async -> Result<ExistsUserLoginResponseEntity, NetworkError>
     func postRegisterFCMToken(token: String) async -> Result<RegisterFCMTokenResponseEntity, NetworkError>

--- a/Treehouse/Treehouse/Domain/UseCases/Register/RegisterTreeMemberUseCase.swift
+++ b/Treehouse/Treehouse/Domain/UseCases/Register/RegisterTreeMemberUseCase.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 protocol PostRegisterTreeMemberUseCaseProtocol {
-    func execute(requestDTO: PostRegisterTreeMemberRequestDTO) async -> Result<RegisterTreeMemberResponseEntity, NetworkError>
+    func execute(registerType: RegisterType, requestDTO: PostRegisterTreeMemberRequestDTO) async -> Result<RegisterTreeMemberResponseEntity, NetworkError>
 }
 
 final class RegisterTreeMemberUseCase: PostRegisterTreeMemberUseCaseProtocol {
@@ -18,7 +18,7 @@ final class RegisterTreeMemberUseCase: PostRegisterTreeMemberUseCaseProtocol {
         self.repository = repository
     }
 
-    func execute(requestDTO: PostRegisterTreeMemberRequestDTO) async -> Result<RegisterTreeMemberResponseEntity, NetworkError> {
-        return await repository.postRegisterTreeMember(requestDTO: requestDTO)
+    func execute(registerType: RegisterType, requestDTO: PostRegisterTreeMemberRequestDTO) async -> Result<RegisterTreeMemberResponseEntity, NetworkError> {
+        return await repository.postRegisterTreeMember(registerType: registerType, requestDTO: requestDTO)
     }
 }

--- a/Treehouse/Treehouse/Network/Base/NetworkServiceManager.swift
+++ b/Treehouse/Treehouse/Network/Base/NetworkServiceManager.swift
@@ -53,7 +53,7 @@ final class NetworkServiceManager: NetworkServiceable {
         
         do {
             let decodingData = try JSONDecoder().decode(BaseResponse<T>.self, from: data)
-            
+            print(decodingData.data)
             switch httpResponse.statusCode {
 
             case 200:

--- a/Treehouse/Treehouse/Network/Register/RegisterAPI.swift
+++ b/Treehouse/Treehouse/Network/Register/RegisterAPI.swift
@@ -11,6 +11,7 @@ enum RegisterAPI {
     case postCheckUserName(requestBody: PostCheckUserNameRequestDTO)
     case postRegisterUser(requestBody: PostRegisterUserRequestDTO)
     case postRegisterTreeMember(requestBody: PostRegisterTreeMemberRequestDTO)
+    case postRegisterTreeMemberMaker(requestBody: PostRegisterTreeMemberRequestDTO)
     case postReissueToken(requestBody: PostReissueTokenRequestDTO)
     case postCheckUserPhone(requestBody: PostCheckUserPhoneRequestDTO)
     case postExistsUserLogin(requestBody: PostExistsUserLoginRequestDTO)
@@ -25,6 +26,7 @@ extension RegisterAPI: BaseRequest {
         case .postCheckUserName: return "users/checkName"
         case .postRegisterUser: return "users/register"
         case .postRegisterTreeMember: return "members/register"
+        case .postRegisterTreeMemberMaker: return "founder/register"
         case .postReissueToken: return "users/reissue"
         case .postCheckUserPhone: return "users/phone"
         case .postExistsUserLogin: return "users/login"
@@ -39,6 +41,7 @@ extension RegisterAPI: BaseRequest {
         case .postCheckUserName: return .post
         case .postRegisterUser: return .post
         case .postRegisterTreeMember: return .post
+        case .postRegisterTreeMemberMaker: return .post
         case .postReissueToken: return .post
         case .postCheckUserPhone: return .post
         case .postExistsUserLogin: return .post
@@ -52,7 +55,7 @@ extension RegisterAPI: BaseRequest {
         switch self {
         case .postCheckUserName, .postRegisterUser, .postCheckUserPhone:
             return .noHeader
-        case .postRegisterTreeMember, .postRegisterFCMToken, .postRegisterPushAgree, .deleteUser:
+        case .postRegisterTreeMember, .postRegisterTreeMemberMaker, .postRegisterFCMToken, .postRegisterPushAgree, .deleteUser:
             return .accessTokenHeader
         case .postReissueToken:
             return .refreshTokenHeader
@@ -70,6 +73,7 @@ extension RegisterAPI: BaseRequest {
         case .postCheckUserName(requestBody: let requestBody): return requestBody
         case .postRegisterUser(requestBody: let requestBody): return requestBody
         case .postRegisterTreeMember(requestBody: let requestBody): return requestBody
+        case .postRegisterTreeMemberMaker(requestBody: let requestBody): return requestBody
         case .postReissueToken(requestBody: let requestBody): return requestBody
         case .postCheckUserPhone(requestBody: let requestBody): return requestBody
         case .postExistsUserLogin(requestBody: let requestBody): return requestBody

--- a/Treehouse/Treehouse/Network/Register/RegisterService.swift
+++ b/Treehouse/Treehouse/Network/Register/RegisterService.swift
@@ -60,6 +60,7 @@ class RegisterService {
         
         switch registerType {
         case .registerUser:
+            print("user 가입")
             let request = NetworkRequest(requestType: RegisterAPI.postRegisterTreeMember(requestBody: requestBody))
             
             guard let makeUrlRequest = request.request() else {
@@ -68,6 +69,7 @@ class RegisterService {
             
             urlRequest = makeUrlRequest
         case .registerTreehouse:
+            print("Treehouse 생성자 가입")
             let request = NetworkRequest(requestType: RegisterAPI.postRegisterTreeMemberMaker(requestBody: requestBody))
             
             guard let makeUrlRequest = request.request() else {

--- a/Treehouse/Treehouse/Network/Register/RegisterService.swift
+++ b/Treehouse/Treehouse/Network/Register/RegisterService.swift
@@ -54,14 +54,29 @@ class RegisterService {
     }
 
     /// 트리하우스 멤버 가입 API
-    func postRegisterTreeMember(requestBody: PostRegisterTreeMemberRequestDTO) async throws -> PostRegisterTreeMemberResponseDTO {
+    func postRegisterTreeMember(registerType: RegisterType, requestBody: PostRegisterTreeMemberRequestDTO) async throws -> PostRegisterTreeMemberResponseDTO {
         
-        let request = NetworkRequest(requestType: RegisterAPI.postRegisterTreeMember(requestBody: requestBody))
+        var urlRequest: URLRequest
         
-        guard let urlRequest = request.request() else {
-            throw NetworkError.clientError(message: "Request 생성불가")
+        switch registerType {
+        case .registerUser:
+            let request = NetworkRequest(requestType: RegisterAPI.postRegisterTreeMember(requestBody: requestBody))
+            
+            guard let makeUrlRequest = request.request() else {
+                throw NetworkError.clientError(message: "Request 생성불가")
+            }
+            
+            urlRequest = makeUrlRequest
+        case .registerTreehouse:
+            let request = NetworkRequest(requestType: RegisterAPI.postRegisterTreeMemberMaker(requestBody: requestBody))
+            
+            guard let makeUrlRequest = request.request() else {
+                throw NetworkError.clientError(message: "Request 생성불가")
+            }
+            
+            urlRequest = makeUrlRequest
         }
-        
+
         return try await networkServiceManager.performRequest(with: urlRequest, decodingType: PostRegisterTreeMemberResponseDTO.self)
     }
     

--- a/Treehouse/Treehouse/Presentation/Auth/RegisterScene/ViewModels/UserPhoneViewModel.swift
+++ b/Treehouse/Treehouse/Presentation/Auth/RegisterScene/ViewModels/UserPhoneViewModel.swift
@@ -25,10 +25,12 @@ final class CheckUserPhoneViewModel: BaseViewModel {
     
     init(checkUserPhoneUseCase: PostCheckUserPhoneUseCaseProtocol) {
         self.checkUserPhoneUseCase = checkUserPhoneUseCase
+        
+        print("Init CheckUserPhoneViewModel")
     }
     
     deinit {
-        print("Deinit UserPhoneViewModel")
+        print("Deinit CheckUserPhoneViewModel")
     }
 }
 

--- a/Treehouse/Treehouse/Presentation/Auth/RegisterScene/ViewModels/UserSettingViewModel.swift
+++ b/Treehouse/Treehouse/Presentation/Auth/RegisterScene/ViewModels/UserSettingViewModel.swift
@@ -18,8 +18,8 @@ enum UserAuthentication {
 }
 
 enum RegisterType {
-    case registerUser
-    case registerTreehouse
+    case registerUser // 일반적인 회원가입
+    case registerTreehouse // treehouse 를 만들고 회원가입
 }
 
 protocol BaseViewModel: AnyObject {}
@@ -125,6 +125,8 @@ final class UserSettingViewModel: BaseViewModel {
         self.presignedURLUseCase = presignedURLUseCase
         self.uploadImageToAWSUseCase = uploadImageToAWSUseCase
         self.registerType = registerType
+        
+        print("Init UserSettingViewModel")
     }
     
     deinit {
@@ -134,13 +136,12 @@ final class UserSettingViewModel: BaseViewModel {
     func createUserInfoData() -> UserInfoData? {
         guard let userId = userId,
               let treehouseId = treehouseId,
-              let memberName = memberName,
-              let bio = bio,
-              let profileImage = accessUrlImage.first else {
+              let profileImage = accessUrlImage.first,
+              let treehouseData = createMemberInfoData() else {
             return nil
         }
         
-        let userData = UserInfoData(userId: userId, userName: userName, profileImageUrl: profileImage, treehouses: [treehouseId], treehouseInfo: [])
+        let userData = UserInfoData(userId: userId, userName: userName, profileImageUrl: profileImage, treehouses: [treehouseId], treehouseInfo: [treehouseData])
         return userData
     }
     
@@ -240,7 +241,9 @@ extension UserSettingViewModel {
             return false
         }
         
-        let result = await registerTreeMemberUseCase.execute(requestDTO: PostRegisterTreeMemberRequestDTO(treehouseId: treehouseId, userName: userName, memberName: memberName, bio: bio, profileImageURL: accessUrlImage.first ?? "" ))
+        print(registerType, treehouseId, userName, memberName, bio, accessUrlImage.first ?? "")
+        
+        let result = await registerTreeMemberUseCase.execute(registerType: registerType, requestDTO: PostRegisterTreeMemberRequestDTO(treehouseId: treehouseId, userName: userName, memberName: memberName, bio: bio, profileImageURL: accessUrlImage.first ?? "" ))
         
         switch result {
         case .success(let response):
@@ -395,7 +398,9 @@ extension UserSettingViewModel {
         
         do {
             let authResult = try await Auth.auth().signIn(with: credential)
-            print("인증 성공!")
+            
+            let user = authResult.user // 인증된 사용자 정보
+            print("인증 성공! 사용자 ID: \(user.uid)")
             
             await MainActor.run {
                 self.isCallCehckVerification = true

--- a/Treehouse/Treehouse/Presentation/Auth/RegisterScene/Views/LoginView.swift
+++ b/Treehouse/Treehouse/Presentation/Auth/RegisterScene/Views/LoginView.swift
@@ -82,6 +82,7 @@ struct LoginView: View {
         }
         .padding(.bottom, SizeLiterals.Screen.screenHeight * 30 / 852)
         .padding(.horizontal, SizeLiterals.Screen.screenWidth * 24 / 393)
+        .background(.grayscaleWhite)
         .navigationBarBackButtonHidden()
         .toolbar {
             ToolbarItem(placement: .topBarLeading) {

--- a/Treehouse/Treehouse/Presentation/Auth/RegisterScene/Views/ReceivedFirstInvitaionView.swift
+++ b/Treehouse/Treehouse/Presentation/Auth/RegisterScene/Views/ReceivedFirstInvitaionView.swift
@@ -78,6 +78,12 @@ struct ReceivedFirstInvitaionView: View {
         .task {
             await viewModel.checkInvitations()
         }
+        .onAppear {
+            let appearance = UINavigationBarAppearance()
+            appearance.backgroundColor = UIColor.gray1
+            appearance.shadowColor = .clear // 하단 선 제거
+            UINavigationBar.appearance().scrollEdgeAppearance = appearance
+        }
         .onDisappear {
             print("ReceivedFirstInvitationView disappeared")
         }

--- a/Treehouse/Treehouse/Presentation/Auth/RegisterScene/Views/SetMemberBioView.swift
+++ b/Treehouse/Treehouse/Presentation/Auth/RegisterScene/Views/SetMemberBioView.swift
@@ -66,6 +66,7 @@ struct SetMemberBioView: View {
         .padding(EdgeInsets(top: 30, leading: 24, bottom: 30, trailing: 24))
         .navigationBarBackButtonHidden()
         .navigationBarTitleDisplayMode(.inline)
+        .background(.grayscaleWhite)
         .toolbar {
             ToolbarItem(placement: .principal) {
                 Text(StringLiterals.Register.navigationTitle1)

--- a/Treehouse/Treehouse/Presentation/Auth/RegisterScene/Views/SetMemberProfileNameView.swift
+++ b/Treehouse/Treehouse/Presentation/Auth/RegisterScene/Views/SetMemberProfileNameView.swift
@@ -101,6 +101,12 @@ struct SetMemberProfileNameView: View {
                 textFieldState = .notFocused
             }
         }
+        .onAppear {
+            let appearance = UINavigationBarAppearance()
+            appearance.backgroundColor = UIColor.grayscaleWhite
+            appearance.shadowColor = .clear // 하단 선 제거
+            UINavigationBar.appearance().scrollEdgeAppearance = appearance
+        }
     }
 }
 

--- a/Treehouse/Treehouse/Presentation/Auth/RegisterScene/Views/ShowMemberProfileView.swift
+++ b/Treehouse/Treehouse/Presentation/Auth/RegisterScene/Views/ShowMemberProfileView.swift
@@ -26,72 +26,74 @@ struct ShowMemberProfileView: View {
     // MARK: - View
     
     var body: some View {
-        Text("\(StringLiterals.Register.registerTitle10)")
-            .foregroundColor(.treeBlack)
-            .font(.fontGuide(.heading1))
-            .fontWithLineHeight(fontLevel: .heading1)
-            .padding(.top, 30)
-            .padding(.leading, 25)
-            .frame(maxWidth: .infinity, alignment: .leading)
-        
-        profileView
-        
-        Spacer()
-        
-        Button(action: {
-            // MARK: - TODO
-            // lottie 추가
-            viewModel.isSignUp = true
-            isRetryButtonDisabled = true
+        VStack(spacing: 0) {
+            Text("\(StringLiterals.Register.registerTitle10)")
+                .foregroundColor(.treeBlack)
+                .font(.fontGuide(.heading1))
+                .fontWithLineHeight(fontLevel: .heading1)
+                .padding(.top, 30)
+                .padding(.leading, 25)
+                .frame(maxWidth: .infinity, alignment: .leading)
             
-            Task {
-                switch viewModel.registerType {
-                case .registerUser:
-                    let result = await viewModel.registerTreeMember()
-                    
-                    guard let createResult = viewModel.createUserInfoData() else { return }
-                                    
-                    let userDataResult = await userInfoViewModel.createData(newData: createResult)
-                    
-                    if result && userDataResult {
-                        isLogin = true
-                        viewRouter.navigate(viewType: .enterTreehouse)
-                    }
-                case .registerTreehouse:
-                    let result = await viewModel.registerTreeMember()
-                    
-                    guard let createResult = viewModel.createMemberInfoData() else { return }
-                    
-                    let userDataResult = userInfoViewModel.addTreehouseInfo(treehouseInfo: createResult)
-                    
-                    if result && userDataResult {
-                        isLogin = true
-                        selectedTreehouseId = viewModel.treehouseId ?? 0
-                        viewRouter.selectedTab = .home
-                        viewRouter.navigate(viewType: .enterTreehouse)
+            profileView
+            
+            Spacer()
+            
+            Button(action: {
+                // MARK: - TODO
+                // lottie 추가
+                viewModel.isSignUp = true
+                isRetryButtonDisabled = true
+                
+                Task {
+                    switch viewModel.registerType {
+                    case .registerUser:
+                        let result = await viewModel.registerTreeMember()
+                        
+                        guard let createResult = viewModel.createUserInfoData() else { return }
+                        
+                        let userDataResult = await userInfoViewModel.createData(newData: createResult)
+                        
+                        if result && userDataResult {
+                            isLogin = true
+                            viewRouter.navigate(viewType: .enterTreehouse)
+                        }
+                    case .registerTreehouse:
+                        let result = await viewModel.registerTreeMember()
+                        
+                        guard let createResult = viewModel.createMemberInfoData() else { return }
+                        
+                        let userDataResult = userInfoViewModel.addTreehouseInfo(treehouseInfo: createResult)
+                        
+                        if result && userDataResult {
+                            isLogin = true
+                            selectedTreehouseId = viewModel.treehouseId ?? 0
+                            viewRouter.selectedTab = .home
+                            viewRouter.navigate(viewType: .enterTreehouse)
+                        }
                     }
                 }
+            }) {
+                Text(StringLiterals.Register.buttonTitle6)
+                    .frame(width: 344, height: 56)
+                    .font(.fontGuide(.body2))
+                    .foregroundColor(.gray1)
+                    .background(.treeBlack)
+                    .cornerRadius(12)
+                    .padding(.horizontal, 24)
             }
-        }) {
-            Text(StringLiterals.Register.buttonTitle6)
-                .frame(width: 344, height: 56)
-                .font(.fontGuide(.body2))
-                .foregroundColor(.gray1)
-                .background(.treeBlack)
-                .cornerRadius(12)
-                .padding(.horizontal, 24)
+            
+            Button(action: {
+                viewRouter.popMultiple(count: 3)
+            }) {
+                Text(StringLiterals.Register.buttonTitle12)
+                    .fontWithLineHeight(fontLevel: .body5)
+                    .foregroundStyle(.gray6)
+                    .underline()
+                    .padding(EdgeInsets(top: 15, leading: 17, bottom: 19, trailing: 17))
+            }
+            .disabled(isRetryButtonDisabled)
         }
-        
-        Button(action: {
-            viewRouter.popMultiple(count: 3)
-        }) {
-            Text(StringLiterals.Register.buttonTitle12)
-                .fontWithLineHeight(fontLevel: .body5)
-                .foregroundStyle(.gray6)
-                .underline()
-                .padding(EdgeInsets(top: 15, leading: 17, bottom: 19, trailing: 17))
-        }
-        .disabled(isRetryButtonDisabled)
         .onAppear {
             if viewModel.registerType == .registerTreehouse {
                 viewModel.userName = userInfoViewModel.userInfo?.userName ?? ""
@@ -99,11 +101,11 @@ struct ShowMemberProfileView: View {
         }
         .navigationBarBackButtonHidden()
         .navigationBarTitleDisplayMode(.inline)
+        .background(.grayscaleWhite)
         .toolbar {
             ToolbarItem(placement: .navigationBarLeading) {
                 Button(action: {
                     viewRouter.pop()
-                    print("뒤로가기 버튼")
                 }) {
                     Image(systemName: "chevron.left")
                         .foregroundColor(.treeBlack)

--- a/Treehouse/Treehouse/Presentation/Auth/RegisterScene/Views/ShowUserProfileView.swift
+++ b/Treehouse/Treehouse/Presentation/Auth/RegisterScene/Views/ShowUserProfileView.swift
@@ -71,6 +71,7 @@ struct ShowUserProfileView: View {
             }
         }
         .padding(EdgeInsets(top: 22, leading: 23, bottom: 2, trailing: 24))
+        .background(.grayscaleWhite)
         .navigationBarBackButtonHidden()
         .toolbar {
             ToolbarItem(placement: .topBarLeading) {
@@ -82,6 +83,12 @@ struct ShowUserProfileView: View {
                 }
                 .padding(.top, 5)
             }
+        }
+        .onAppear {
+            let appearance = UINavigationBarAppearance()
+            appearance.backgroundColor = UIColor.grayscaleWhite
+            appearance.shadowColor = .clear // 하단 선 제거
+            UINavigationBar.appearance().scrollEdgeAppearance = appearance
         }
     }
 }

--- a/Treehouse/Treehouse/Presentation/Auth/RegisterScene/Views/UnableRegisterView.swift
+++ b/Treehouse/Treehouse/Presentation/Auth/RegisterScene/Views/UnableRegisterView.swift
@@ -63,6 +63,7 @@ struct UnableRegisterView: View {
             .padding(.bottom, SizeLiterals.Screen.screenHeight * 30 / 852)
         }
         .padding(.horizontal, SizeLiterals.Screen.screenWidth * 24 / 393)
+        .background(.grayscaleWhite)
         .navigationBarBackButtonHidden()
         .toolbar {
             ToolbarItem(placement: .topBarLeading) {

--- a/Treehouse/Treehouse/Presentation/Auth/RegisterScene/Views/VerificationView.swift
+++ b/Treehouse/Treehouse/Presentation/Auth/RegisterScene/Views/VerificationView.swift
@@ -117,6 +117,7 @@ struct VerificationView: View {
         }
         .padding(.horizontal, SizeLiterals.Screen.screenWidth * 24 / 393)
         .padding(.bottom, SizeLiterals.Screen.screenHeight * 30 / 852)
+        .background(.grayscaleWhite)
         .onTapGesture {
             hideKeyboard()
         }


### PR DESCRIPTION
## 📟 관련 이슈
- Resolved: #133 

## 👷 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
- Treehouse 설립자 멤버 가입을 위한 `postRegisterTreeMemberMaker` API 추가
- Treehouse 를 만들고 Member 정보 입력 관련 로직 수정
- UI 관련 배경색 수정

<br>

## 🚨 참고 사항
<!-- 참고 사항을 적어주세요. 없으면 지워주세요. -->

``` swift
/// 트리하우스 멤버 가입 API
    func postRegisterTreeMember(registerType: RegisterType, requestBody: PostRegisterTreeMemberRequestDTO) async throws -> PostRegisterTreeMemberResponseDTO {
        
        var urlRequest: URLRequest
        
        switch registerType {
        case .registerUser:
            print("user 가입")
            let request = NetworkRequest(requestType: RegisterAPI.postRegisterTreeMember(requestBody: requestBody))
            
            guard let makeUrlRequest = request.request() else {
                throw NetworkError.clientError(message: "Request 생성불가")
            }
            
            urlRequest = makeUrlRequest
        case .registerTreehouse:
            print("Treehouse 생성자 가입")
            let request = NetworkRequest(requestType: RegisterAPI.postRegisterTreeMemberMaker(requestBody: requestBody))
            
            guard let makeUrlRequest = request.request() else {
                throw NetworkError.clientError(message: "Request 생성불가")
            }
            
            urlRequest = makeUrlRequest
        }

        return try await networkServiceManager.performRequest(with: urlRequest, decodingType: PostRegisterTreeMemberResponseDTO.self)
    }
```
Treehouse 설립자가 멤버 정보를 입력하고 가입 시 초대장이 없기 때문에 오류가 발생했습니다. 
이 부분을 해결하고자 서버 선생님께 말씀 드렸고 새로운 API 를 만들어주셨습니다.

기존 트리하우스 멤버 가입 API 와 큰 차이점은 없습니다.
다만 설립자가 가입 시 사용하는 엔드포인트가 변경되어 registerType 를 두어 분기처리를 진행했습니다.

<br>

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
