### PR TITLE
[Feat] #136 - 키보드가 올라왔을 때 댓글이 가려지는 문제 해결

### DIFF
--- a/Treehouse/Treehouse.xcodeproj/project.pbxproj
+++ b/Treehouse/Treehouse.xcodeproj/project.pbxproj
@@ -126,7 +126,7 @@
 		3F81715D2C43847A00CEE21E /* ExistsUserLoginResponseEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F81715C2C43847A00CEE21E /* ExistsUserLoginResponseEntity.swift */; };
 		3F81715F2C4384E600CEE21E /* ExistsUserLoginUserCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F81715E2C4384E600CEE21E /* ExistsUserLoginUserCase.swift */; };
 		3F8171642C4399B700CEE21E /* UserLoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F8171632C4399B700CEE21E /* UserLoginViewModel.swift */; };
-		3F8171662C43A27300CEE21E /* UserPhoneViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F8171652C43A27300CEE21E /* UserPhoneViewModel.swift */; };
+		3F8171662C43A27300CEE21E /* CheckUserPhoneViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F8171652C43A27300CEE21E /* CheckUserPhoneViewModel.swift */; };
 		3F8171682C43FE6F00CEE21E /* CreateCommentResponseEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F8171672C43FE6F00CEE21E /* CreateCommentResponseEntity.swift */; };
 		3F81716A2C43FEB800CEE21E /* CreateCommentUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F8171692C43FEB800CEE21E /* CreateCommentUseCase.swift */; };
 		3F81716C2C44002900CEE21E /* ReadCommentUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F81716B2C44002900CEE21E /* ReadCommentUseCase.swift */; };
@@ -442,7 +442,7 @@
 		3F81715C2C43847A00CEE21E /* ExistsUserLoginResponseEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExistsUserLoginResponseEntity.swift; sourceTree = "<group>"; };
 		3F81715E2C4384E600CEE21E /* ExistsUserLoginUserCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExistsUserLoginUserCase.swift; sourceTree = "<group>"; };
 		3F8171632C4399B700CEE21E /* UserLoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserLoginViewModel.swift; sourceTree = "<group>"; };
-		3F8171652C43A27300CEE21E /* UserPhoneViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserPhoneViewModel.swift; sourceTree = "<group>"; };
+		3F8171652C43A27300CEE21E /* CheckUserPhoneViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckUserPhoneViewModel.swift; sourceTree = "<group>"; };
 		3F8171672C43FE6F00CEE21E /* CreateCommentResponseEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateCommentResponseEntity.swift; sourceTree = "<group>"; };
 		3F8171692C43FEB800CEE21E /* CreateCommentUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateCommentUseCase.swift; sourceTree = "<group>"; };
 		3F81716B2C44002900CEE21E /* ReadCommentUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadCommentUseCase.swift; sourceTree = "<group>"; };
@@ -1265,7 +1265,7 @@
 			children = (
 				3F8845FF2BF095F60021FB79 /* UserSettingViewModel.swift */,
 				3F8171632C4399B700CEE21E /* UserLoginViewModel.swift */,
-				3F8171652C43A27300CEE21E /* UserPhoneViewModel.swift */,
+				3F8171652C43A27300CEE21E /* CheckUserPhoneViewModel.swift */,
 				3FEC57742C8F49F60080DF96 /* FCMTokenViewModel.swift */,
 				3FEC57762C8F4A080080DF96 /* RegisterPushNotiViewModel.swift */,
 			);
@@ -2298,7 +2298,7 @@
 				944D48952BF10CA000205B18 /* SinglePostView.swift in Sources */,
 				3FFA73142C3178F800C3AF4F /* Image+.swift in Sources */,
 				0012366F2BD1831300CEAC53 /* PhoneNumberSearchBar.swift in Sources */,
-				3F8171662C43A27300CEE21E /* UserPhoneViewModel.swift in Sources */,
+				3F8171662C43A27300CEE21E /* CheckUserPhoneViewModel.swift in Sources */,
 				3FEC57612C8F23B80080DF96 /* TreeBranchViewModel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Treehouse/Treehouse/Global/SwiftData/UserInfoDataSource.swift
+++ b/Treehouse/Treehouse/Global/SwiftData/UserInfoDataSource.swift
@@ -38,13 +38,18 @@ final class UserInfoDataSource {
     func fetchItem() -> UserInfoData? {
         do {
             let data = try modelContext.fetch(FetchDescriptor<UserInfoData>())
+            
             data.forEach {
                 print($0.userName)
             }
-            print("유저 정보 불러오기: \(String(describing: data.first?.userName))")
+            print("유저 이름: \(String(describing: data.first?.userName))")
+            print("유저 프로필: \(String(describing: data.first?.profileImageUrl))")
+            print("가입한 Treehouse: \(String(describing: data.first?.treehouses))")
             
             data.first?.treehouseInfo.forEach {
-                print("유저 정보 불러오기: \(String(describing: $0.treehouseName))")
+                print("첫번째 Treehouse ID: \(String(describing: $0.treehouseId))")
+                print("첫번째 Treehouse Name: \(String(describing: $0.treehouseName))")
+                print("첫번째 Treehouse Member ID: \(String(describing: $0.treehouseMemberId))")
             }
     
             return data.first

--- a/Treehouse/Treehouse/Global/SwiftData/UserInfoViewModel.swift
+++ b/Treehouse/Treehouse/Global/SwiftData/UserInfoViewModel.swift
@@ -69,6 +69,8 @@ final class UserInfoViewModel: BaseViewModel {
     
     /// TreehouseInfo 추가하기 위한 메서드
     func addTreehouseInfo(treehouseInfo: TreehouseInfo) -> Bool {
+        let _ = modifyTreehouse(treehouseId: treehouseInfo.treehouseId)
+        
         if let data = userInfo {
             data.treehouseInfo.append(treehouseInfo)
         }
@@ -93,7 +95,7 @@ private extension UserInfoViewModel {
     
     /// 이미 저장된 데이터를 수정하기 위해 다시 저장하는 메서드
     func updateData() -> Bool {
-        guard let data = userInfo else { return false }
+        guard let _ = userInfo else { return false }
         
         switch dataSource.saveUserInfo() {
         case .success(let result):

--- a/Treehouse/Treehouse/Presentation/Auth/RegisterScene/ViewModels/CheckUserPhoneViewModel.swift
+++ b/Treehouse/Treehouse/Presentation/Auth/RegisterScene/ViewModels/CheckUserPhoneViewModel.swift
@@ -1,5 +1,5 @@
 //
-//  UserPhoneViewModel.swift
+//  CheckUserPhoneViewModel.swift
 //  Treehouse
 //
 //  Created by ParkJunHyuk on 7/14/24.

--- a/Treehouse/Treehouse/Presentation/Feed/FeedContentScene/Views/CommentView.swift
+++ b/Treehouse/Treehouse/Presentation/Feed/FeedContentScene/Views/CommentView.swift
@@ -93,6 +93,7 @@ struct CommentView: View {
                         focusedField.wrappedValue = .post
                         commentViewModel.createCommentMemberName = userProfile.memberName
                         commentViewModel.commentState = .createReplyComment
+                        commentViewModel.selectComment(commentId)
                     }) {
                         Text("답글 달기")
                             .fontWithLineHeight(fontLevel: .body4)
@@ -104,6 +105,7 @@ struct CommentView: View {
                         focusedField.wrappedValue = .post
                         commentViewModel.createCommentMemberName = userProfile.memberName
                         commentViewModel.commentState = .createReplyComment
+                        commentViewModel.selectComment(commentId)
                     }) {
                         Text("답글 달기")
                             .fontWithLineHeight(fontLevel: .body4)

--- a/Treehouse/Treehouse/Presentation/Feed/FeedContentScene/Views/FeedContentView.swift
+++ b/Treehouse/Treehouse/Presentation/Feed/FeedContentScene/Views/FeedContentView.swift
@@ -31,6 +31,7 @@ struct FeedContentView: View {
                             reactionData: comment.reactionList,
                             focusedField: focusedField,
                             isReplayList: !comment.replyList.isEmpty)
+                    .id(comment.commentId)
                     .padding(EdgeInsets(top: 10, leading: 16, bottom: 10, trailing: 16))
                 
                 replyView(reply: comment.replyList)
@@ -49,16 +50,17 @@ private extension FeedContentView {
     @ViewBuilder
     func replyView(reply: [ReplyListEntity]?) -> some View {
         if let data = reply {
-            ForEach(data) {
+            ForEach(data) { replyComment in
                 CommentView(commentType: .reply,
-                            commentId: $0.commentId,
-                            userProfile: $0.memberProfile,
-                            time: $0.commentedAt,
-                            comment: $0.context,
-                            reactionData: $0.reactionList, 
+                            commentId: replyComment.commentId,
+                            userProfile: replyComment.memberProfile,
+                            time: replyComment.commentedAt,
+                            comment: replyComment.context,
+                            reactionData: replyComment.reactionList,
                             focusedField: focusedField,
                             isReplayList: true,
-                            lastData: $0.commentId == data.last?.commentId)
+                            lastData: replyComment.commentId == data.last?.commentId)
+                .id(replyComment.commentId)
                 .environment(emojiViewModel)
             }
         }

--- a/Treehouse/Treehouse/Presentation/Feed/FeedScene/ViewModels/CommentViewModel.swift
+++ b/Treehouse/Treehouse/Presentation/Feed/FeedScene/ViewModels/CommentViewModel.swift
@@ -27,6 +27,7 @@ final class CommentViewModel: BaseViewModel {
         readCommentData ?? []
     }
     
+    var selectedCommentId: Int?
     var postContent: String = ""
     var errorMessage: String = ""
     var isSelectEmojiView = false
@@ -81,6 +82,10 @@ final class CommentViewModel: BaseViewModel {
                 }
             }
         }
+    }
+    
+    func selectComment(_ id: Int) {
+        selectedCommentId = id
     }
 }
 


### PR DESCRIPTION
## 📟 관련 이슈
- Resolved: #136 

<br>

## 👷 작업한 내용
- 키보드가 올라왔을 때 댓글이 가려지는 현상을 해결
- UserInfo 를 저장하는 로직 수정 - 가입한 treehouseId 저장 

<br>

## 📸 스크린샷

https://github.com/user-attachments/assets/7eceebbd-3b16-4a43-86c0-2015e8f9ddc9

<br>

## 🚨 참고 사항
<!-- 참고 사항을 적어주세요. 없으면 지워주세요. -->

### ` FeedContentView ` 에 댓글 View 에 고유 식별 ID 적용

``` swift
struct FeedContentView: View {
    // 댓글에 대한 id 설정
    CommentView( // .... )
        .id(comment.commentId)

    // 대댓글에 대한 id 설정
    CommentView( // .... )
        .id(replyComment.commentId)
}
```

다음과 같이 댓글, 대댓글에 대한 `id` 값을 부여했습니다.
`id` 는 SwiftUI 에서 각 뷰를 고유하게 식별하는데 사용하게 됩니다. 
어떤 뷰가 업데이트 됐는지 추적하거나 어떤 뷰를 업데이트하고, 재사용할지 결정하는 역할을 하기도 하지만

여기서는 특정 위치로의 스크롤을 위해서 ID 값을 사용하고자 합니다.
댓글에 있는 댓글 달기 버튼을 누르면 `commentViewModel.selectComment()` 로 id 값이 전달 됩니다.

<br>

### ` PostDetailView ` 의 ` ScrollViewReader ` 로 해당 댓글이 안가려지게 스크롤

``` swift
struct PostDetailView: View {
        ScrollViewReader { proxy in
                ScrollView {
                    VStack {
                        // ... 
                    }
                }
                .onChange(of: commentViewModel.selectedCommentId) { _, newValue in
                    if let id = newValue {
                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
                            withAnimation {
                                proxy.scrollTo(id, anchor: .center)
                            }
                        }
                    }
                }
        }
}
```

ScrollViewReader 는 프로그래밍 방식으로 ScrollView 내의 특정 위치로 스크롤 가능하게 해주는 컴포넌트 입니다.
해당 컴포넌트는 

- 특정 ID 를 가진 View 로 스크롤 을 하거나
- 스크롤 관련 애니메이션을 적용
- 특정 조건에서 스크롤 가능하게 

하는 역할을 합니다.

여기서는 `commentViewModel.selectComment()` 로 id 값이 전달 되고 부모 뷰인 PostDetailView 에서 해당 id 값으로 스크롤 을 하도록 되어있습니다. 

<br>

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
