### PR TITLE
[Feat] #142 - FirebaseCrashlytics 추가 및 세부 로그 저장 로직 구현

### DIFF
--- a/Treehouse/Treehouse.xcodeproj/project.pbxproj
+++ b/Treehouse/Treehouse.xcodeproj/project.pbxproj
@@ -116,6 +116,7 @@
 		3F51505C2C0EDFE400AD05C3 /* CheckInvitationsUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F51505B2C0EDFE400AD05C3 /* CheckInvitationsUseCase.swift */; };
 		3F5189E72C520B2E00982B5B /* PostExistsUserLoginRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F5189E62C520B2E00982B5B /* PostExistsUserLoginRequestDTO.swift */; };
 		3F6801CD2C5FC065005E694E /* CustomAlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F6801CC2C5FC065005E694E /* CustomAlertView.swift */; };
+		3F6A114E2C9C00EB00F039AA /* FirebaseCrashlytics in Frameworks */ = {isa = PBXBuildFile; productRef = 3F6A114D2C9C00EB00F039AA /* FirebaseCrashlytics */; };
 		3F6E13C02C7B779D00F94595 /* DeleteUserResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F6E13BF2C7B779D00F94595 /* DeleteUserResponseDTO.swift */; };
 		3F6E13C22C7B7DFD00F94595 /* DeleteUserUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F6E13C12C7B7DFD00F94595 /* DeleteUserUseCase.swift */; };
 		3F6E13C42C7B7E4900F94595 /* DeleteUserResponseEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F6E13C32C7B7E4900F94595 /* DeleteUserResponseEntity.swift */; };
@@ -656,6 +657,7 @@
 				00CF35A22BC2F42F00D9E332 /* Moya in Frameworks */,
 				00CF35A02BC2F42F00D9E332 /* CombineMoya in Frameworks */,
 				3FA085C12C773991001D3E90 /* FirebaseAuth in Frameworks */,
+				3F6A114E2C9C00EB00F039AA /* FirebaseCrashlytics in Frameworks */,
 				00CF35A62BC2F42F00D9E332 /* RxMoya in Frameworks */,
 				3FA085BF2C773991001D3E90 /* FirebaseAnalytics in Frameworks */,
 				00CF35A42BC2F42F00D9E332 /* ReactiveMoya in Frameworks */,
@@ -1931,6 +1933,7 @@
 				3FA085BE2C773991001D3E90 /* FirebaseAnalytics */,
 				3FA085C02C773991001D3E90 /* FirebaseAuth */,
 				3FA085C22C773991001D3E90 /* FirebaseMessaging */,
+				3F6A114D2C9C00EB00F039AA /* FirebaseCrashlytics */,
 			);
 			productName = Treehouse;
 			productReference = 00CF357E2BC291FA00D9E332 /* Treehouse.app */;
@@ -2625,6 +2628,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 00CF35B72BC306D500D9E332 /* XCRemoteSwiftPackageReference "SVGKit" */;
 			productName = SVGKitSwift;
+		};
+		3F6A114D2C9C00EB00F039AA /* FirebaseCrashlytics */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3FA085BD2C773991001D3E90 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseCrashlytics;
 		};
 		3FA085BE2C773991001D3E90 /* FirebaseAnalytics */ = {
 			isa = XCSwiftPackageProductDependency;


### PR DESCRIPTION
## 📟 관련 이슈
- Resolved: #142 

<br>

## 👷 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
- FirebaseCrashlytics 추가
- 전화번호 인증 로직이 성공했는지, 실패했는지 로그 저장 코드 구현

<br>

## 🚨 참고 사항
<!-- 참고 사항을 적어주세요. 없으면 지워주세요. -->

``` swift
func certificationPhoneNumber() async {
        guard let phoneNumber = phoneNumber else { return }
        
        let fixPhoneNumber = "+82" + phoneNumber.dropFirst(1)

        do {
            self.verificationID = try await PhoneAuthProvider.provider().verifyPhoneNumber(fixPhoneNumber, uiDelegate: nil)
            
            // 서버 통신 성공, verificationID를 저장
            if let verificationID = verificationID {
                // Crashlytics 로그 추가
                Crashlytics.crashlytics().log("Phone authentication successful")
                
                UserDefaults.standard.set(verificationID, forKey: "authVerificationID")
            }
            
            await MainActor.run {
                self.isVerificationID = true
            }
        } catch let error as NSError {
            // Crashlytics 로그 추가
            Crashlytics.crashlytics().log("Phone authentication failed")
            Crashlytics.crashlytics().setCustomValue(fixPhoneNumber, forKey: "phone_number")
            Crashlytics.crashlytics().setCustomValue(error.localizedDescription, forKey: "error_message")
            
            // userInfo의 내용을 그대로 저장
            let userInfo = error.userInfo
            for (key, value) in userInfo {
                Crashlytics.crashlytics().setCustomValue(value, forKey: key)
            }
            
            await MainActor.run {
                print(error.userInfo)
                errorMessage = "인증 실패: \(error.localizedDescription)"
            }
        }
    }
}
```

다음과 같이 기존의 Analytics 는 세부 로그를 보기 어려웠습니다.
그래서 FirebaseCrashlytics 를 추가하여 세부 로그를 저장 시켜 성공 유무를 체크하고자 합니다.

<br>

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
