### PR TITLE
[Feat] #148 - 최상단에 표시할 Alert ViewModifier 구현 및 전화번호 인증, 초대 관련 로직 수정

### DIFF
--- a/Treehouse/Treehouse.xcodeproj/project.pbxproj
+++ b/Treehouse/Treehouse.xcodeproj/project.pbxproj
@@ -92,6 +92,8 @@
 		3F2DB2792BCFF5FE00DEFBA6 /* ReceivedInvitationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F2DB2782BCFF5FE00DEFBA6 /* ReceivedInvitationView.swift */; };
 		3F2DB27B2BD0C83900DEFBA6 /* InvitationAlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F2DB27A2BD0C83900DEFBA6 /* InvitationAlertView.swift */; };
 		3F2DB27D2BD0F35900DEFBA6 /* InvitationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F2DB27C2BD0F35900DEFBA6 /* InvitationView.swift */; };
+		3F2F62462CA00844005E5DC1 /* AuthPhoneNumAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F2F62452CA00844005E5DC1 /* AuthPhoneNumAlert.swift */; };
+		3F2F62482CA04136005E5DC1 /* InvitationAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F2F62472CA04136005E5DC1 /* InvitationAlert.swift */; };
 		3F32DAC22C5B89EF001786BC /* CreateTreehouseRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F32DAC12C5B89EF001786BC /* CreateTreehouseRouter.swift */; };
 		3F3DAE982C57D09800C1424C /* ReportCommentUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F3DAE972C57D09800C1424C /* ReportCommentUseCase.swift */; };
 		3F3DAE9B2C588CE900C1424C /* TreehouseViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F3DAE9A2C588CE900C1424C /* TreehouseViewModel.swift */; };
@@ -408,6 +410,8 @@
 		3F2DB2782BCFF5FE00DEFBA6 /* ReceivedInvitationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceivedInvitationView.swift; sourceTree = "<group>"; };
 		3F2DB27A2BD0C83900DEFBA6 /* InvitationAlertView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvitationAlertView.swift; sourceTree = "<group>"; };
 		3F2DB27C2BD0F35900DEFBA6 /* InvitationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvitationView.swift; sourceTree = "<group>"; };
+		3F2F62452CA00844005E5DC1 /* AuthPhoneNumAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthPhoneNumAlert.swift; sourceTree = "<group>"; };
+		3F2F62472CA04136005E5DC1 /* InvitationAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvitationAlert.swift; sourceTree = "<group>"; };
 		3F32DAC12C5B89EF001786BC /* CreateTreehouseRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateTreehouseRouter.swift; sourceTree = "<group>"; };
 		3F3DAE972C57D09800C1424C /* ReportCommentUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportCommentUseCase.swift; sourceTree = "<group>"; };
 		3F3DAE9A2C588CE900C1424C /* TreehouseViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TreehouseViewModel.swift; sourceTree = "<group>"; };
@@ -1379,6 +1383,8 @@
 				3F6801CC2C5FC065005E694E /* CustomAlertView.swift */,
 				3FA541542C60F06200723BAD /* LottieView.swift */,
 				3F25A3532C91C580006E2715 /* InvitationTreehouseView.swift */,
+				3F2F62452CA00844005E5DC1 /* AuthPhoneNumAlert.swift */,
+				3F2F62472CA04136005E5DC1 /* InvitationAlert.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -2030,6 +2036,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				3F3DAE982C57D09800C1424C /* ReportCommentUseCase.swift in Sources */,
+				3F2F62482CA04136005E5DC1 /* InvitationAlert.swift in Sources */,
 				3FF48FD42C4DF69E00A6DD8A /* PostViewModel.swift in Sources */,
 				3FDCDA332C63B84400C7F7B6 /* PostCheckTreehouseNameRequestDTO.swift in Sources */,
 				3FEC576F2C8F49460080DF96 /* RegisterPushAgreeUseCase.swift in Sources */,
@@ -2320,6 +2327,7 @@
 				946424AC2C3E4F8100BB177F /* NotificationRepositoryProtocol.swift in Sources */,
 				0087C2872BDEC7B0004CED9C /* RegisterRepositoryImpl.swift in Sources */,
 				9412FF392BFF2466006A8A15 /* TabViewType.swift in Sources */,
+				3F2F62462CA00844005E5DC1 /* AuthPhoneNumAlert.swift in Sources */,
 				3F8530EE2C5382E3003FA07A /* ReadDetailFeedPostUseCase.swift in Sources */,
 				3FE00F102BC7E29700CC821E /* TextFieldStateType.swift in Sources */,
 				944D48952BF10CA000205B18 /* SinglePostView.swift in Sources */,

--- a/Treehouse/Treehouse/Global/Components/AuthPhoneNumAlert.swift
+++ b/Treehouse/Treehouse/Global/Components/AuthPhoneNumAlert.swift
@@ -1,0 +1,44 @@
+//
+//  AuthPhoneNumAlert.swift
+//  Treehouse
+//
+//  Created by ParkJunHyuk on 9/22/24.
+//
+
+import SwiftUI
+
+struct AuthPhoneNumAlert: View {
+    
+    var authState: PhoneNumberAuthState?
+    var onConfirm: () -> Void
+    
+    var body: some View {
+        VStack(spacing: 41) {
+            Text(authState?.title ?? "정보 없음")
+                .fontWithLineHeight(fontLevel: .heading4)
+                .multilineTextAlignment(.center)
+
+            Button(action: {
+                onConfirm()
+            }) {
+                Text("확인")
+                    .fontWithLineHeight(fontLevel: .body3)
+                    .foregroundStyle(.grayscaleWhite)
+                    .padding(.vertical, 11)
+                    .frame(maxWidth: .infinity)
+                    .background(.grayscaleBlack)
+            }
+            .clipShape(RoundedRectangle(cornerRadius: 8.0))
+            
+        }
+        .padding(EdgeInsets(top: 25.0, leading: 14.0, bottom: 14.0, trailing: 14.0))
+        .frame(maxWidth: .infinity)
+        .background(.gray1)
+        .clipShape(RoundedRectangle(cornerRadius: 12.0))
+        .padding(.horizontal, 21)
+    }
+}
+
+#Preview {
+    AuthPhoneNumAlert(authState: .success, onConfirm: {})
+}

--- a/Treehouse/Treehouse/Global/Components/InvitationAlert.swift
+++ b/Treehouse/Treehouse/Global/Components/InvitationAlert.swift
@@ -1,0 +1,98 @@
+//
+//  InvitationAlert.swift
+//  Treehouse
+//
+//  Created by ParkJunHyuk on 9/22/24.
+//
+
+import SwiftUI
+
+enum invitationState {
+    case success
+    case faliure
+}
+struct InvitationAlert: View {
+    
+    var invitationState: invitationState
+    var memberName: String
+    var onCancel: () -> Void
+    var onConfirm: () -> Void
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            Image(.icInvitation)
+                .resizable()
+                .scaledToFit()
+                .frame(width: SizeLiterals.Screen.screenWidth * 84 / 393, height: SizeLiterals.Screen.screenHeight * 84 / 852)
+                .padding(.bottom, 10)
+            
+            invitationStateContent
+        }
+        .padding(EdgeInsets(top: 14.0, leading: 13.0, bottom: 14.0, trailing: 13.0))
+        .background(.grayscaleWhite)
+        .clipShape(RoundedRectangle(cornerRadius: 12.0))
+        .padding(.horizontal, 22)
+    }
+    
+    @ViewBuilder
+    var invitationStateContent: some View {
+        switch invitationState {
+        case .success:
+            Text("\(memberName)에게\n초대장을 보내시겠습니까?")
+                .fontWithLineHeight(fontLevel: .heading4)
+                .multilineTextAlignment(.center)
+                .padding(.bottom, 29)
+            
+            HStack(spacing: 12) {
+                Button(action: {
+                    onCancel()
+                }) {
+                    Text("취소")
+                        .fontWithLineHeight(fontLevel: .body3)
+                        .foregroundStyle(.treeBlack)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 11)
+                        .background(.grayscaleWhite)
+                }
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(.treeBlack, lineWidth: 1.5)
+                )
+                .cornerRadius(8)
+                
+                Button(action: {
+                    onConfirm()
+                }) {
+                    Text("보내기")
+                        .fontWithLineHeight(fontLevel: .body3)
+                        .foregroundStyle(.grayscaleWhite)
+                        .padding(.vertical, 11)
+                        .frame(maxWidth: .infinity)
+                        .background(.grayscaleBlack)
+                }
+                .clipShape(RoundedRectangle(cornerRadius: 8.0))
+            }
+        case .faliure:
+            Text("사용할 수 있는 초대장이 없습니다")
+                .fontWithLineHeight(fontLevel: .heading4)
+                .multilineTextAlignment(.center)
+                .padding(.bottom, 29)
+            
+            Button(action: {
+                onConfirm()
+            }) {
+                Text("확인")
+                    .fontWithLineHeight(fontLevel: .body3)
+                    .foregroundStyle(.grayscaleWhite)
+                    .padding(.vertical, 11)
+                    .frame(maxWidth: .infinity)
+                    .background(.grayscaleBlack)
+            }
+            .clipShape(RoundedRectangle(cornerRadius: 8.0))
+        }
+    }
+}
+
+#Preview {
+    InvitationAlert(invitationState: .faliure, memberName: "아무개", onCancel: {}, onConfirm: {})
+}

--- a/Treehouse/Treehouse/Network/Base/NetworkServiceManager.swift
+++ b/Treehouse/Treehouse/Network/Base/NetworkServiceManager.swift
@@ -79,7 +79,11 @@ final class NetworkServiceManager: NetworkServiceable {
                     throw NetworkError.clientError(message: decodingData.message)
                 }
                 
-                return nil
+                if NetworkErrorCode.invitationError.contains(decodingData.code) {
+                    throw NetworkError.clientError(message: decodingData.message)
+                }
+                
+                throw NetworkError.clientError(message: "Unknown 400 error")
                 
             case 401...409:
                 try await postReissueToken()

--- a/Treehouse/Treehouse/Network/Error/NetworkErrorCode.swift
+++ b/Treehouse/Treehouse/Network/Error/NetworkErrorCode.swift
@@ -20,4 +20,6 @@ enum NetworkErrorCode {
                                  "AUTH404_1",
                                  "USER404_1",
                                  "USER409_1"]
+    
+    static let invitationError = ["INVITATION400_1"]
 }

--- a/Treehouse/Treehouse/Presentation/Auth/RegisterScene/Views/VerificationView.swift
+++ b/Treehouse/Treehouse/Presentation/Auth/RegisterScene/Views/VerificationView.swift
@@ -26,6 +26,8 @@ struct VerificationView: View {
     // MARK: - View
     
     var body: some View {
+        @Bindable var viewModel = viewModel
+        
         VStack(spacing: 0) {
             VStack(alignment: .leading, spacing: 0) {
                 HStack(spacing: 0) {
@@ -123,10 +125,15 @@ struct VerificationView: View {
         }
         .navigationBarBackButtonHidden()
         .onAppear {
-            isKeyboardShowing = true
-        }
-        .task {
-            await viewModel.certificationPhoneNumber()
+            Task {
+                let result = await viewModel.certificationPhoneNumber()
+                
+                if result == true {
+                    await MainActor.run {
+                        isKeyboardShowing = result
+                    }
+                }
+            }
         }
         .toolbar {
             ToolbarItem(placement: .topBarLeading) {
@@ -145,6 +152,9 @@ struct VerificationView: View {
                 }
                 .frame(maxWidth: .infinity, alignment: .trailing)
             }
+        }
+        .topLevelAlert(isPresented: $viewModel.isAuthAlert) {
+            AuthPhoneNumAlert(authState: viewModel.isSendAuthMessageState, onConfirm: { viewModel.isAuthAlert = false })
         }
     }
     


### PR DESCRIPTION
## 📟 관련 이슈
- Resolved: #148 

<br>

## 👷 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
- 최상단에 Alert 을 보여줄 CustomAlertModifier 구현
- 전화번호 인증 시 잦은 요청으로 불가능할 때 보여줄 Alert 구현
- 다른 사람 초대 관련 Alert 구현

<br>

## 📸 스크린샷
|기능|초대 가능|초대 불가능|
|:--:|:--:|:--:|
|GIF|<img src = "https://github.com/user-attachments/assets/0a7aee11-48b6-45f7-a205-2065aca91776" width ="250">|<img src = "https://github.com/user-attachments/assets/759830a2-5988-42a4-87d9-292f17ed3618" width ="250">|

<br>

- 인증 가능 시

https://github.com/user-attachments/assets/07dde6de-ccbe-4c4c-9bbd-b18bc91e0739

- 인증 불가능 시

https://github.com/user-attachments/assets/88e89985-1aac-4e0a-8820-bf11f674947d

<br>

## 🚨 참고 사항
<!-- 참고 사항을 적어주세요. 없으면 지워주세요. -->

``` swift
struct CustomAlertModifier<AlertContent: View>: ViewModifier {
    @Binding var isPresented: Bool
    let alertContent: () -> AlertContent
    
    @State private var overlayWindow: UIWindow?
    
    func body(content: Content) -> some View {
        content
            .onChange(of: isPresented) { _, newValue in
                if newValue {
                    showOverlay()
                } else {
                    hideOverlay()
                }
            }
    }
    
    private func showOverlay() {
        let window = UIWindow(windowScene: UIApplication.shared.connectedScenes.first as! UIWindowScene)
        
        let overlayVC = UIHostingController(rootView:
            ZStack {
                Color.black.opacity(0.4)
                    .edgesIgnoringSafeArea(.all)
                    .onTapGesture {
                        isPresented = false
                    }
                
                alertContent()
            }
            .ignoresSafeArea()
        )
        
        overlayVC.view.backgroundColor = .clear

        window.rootViewController = overlayVC
        window.isHidden = false
        self.overlayWindow = window
    }
    
    private func hideOverlay() {
        overlayWindow?.isHidden = true
        overlayWindow = nil
    }
}
```

다음과 같이 ViewModifier 를 작성했습니다. 
ZStack 으로만 구현 시 NavigationTitle 이나 SafeArea 지역에서는 적용되지 않는 문제가 발생하게 됩니다.
현재 뷰 계층 구조에서 Navigation 관계 없이 최상위에 표기를 하고자 UIWIndow 를 사용하여 해결합니다.

``` swift
.topLevelAlert(isPresented: $viewModel.isAuthAlert) {
        // 띄울 Alert View
}
```

사용하실 때는 다음과 같이 작성해주시면 됩니다.

<br>

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
