### PR TITLE
[Fix] #150 - 회원가입 및 MyProfile 관련 로직 수정

### DIFF
--- a/Treehouse/Treehouse/Global/Components/InvitationView.swift
+++ b/Treehouse/Treehouse/Global/Components/InvitationView.swift
@@ -125,13 +125,13 @@ extension InvitationView {
             .padding(.top, SizeLiterals.Screen.screenHeight * 27.27 / 852)
             .padding(.bottom, SizeLiterals.Screen.screenHeight * 20.72 / 852)
             
-            Text(treehouseName)
+            Text(viewModel.treehouseName)
                 .fontWithLineHeight(fontLevel: .heading2)
                 .foregroundStyle(.treeBlack)
                 .padding(.bottom, 6)
             
             HStack(spacing: 0) {
-                Text("\(invitedMember)님")
+                Text("\(viewModel.invitedMember)님")
                     .fontWithLineHeight(fontLevel: .body2)
                 Text("이 당신을 초대했습니다.")
                     .fontWithLineHeight(fontLevel: .body3)
@@ -147,7 +147,7 @@ extension InvitationView {
                 }
                 .padding(.trailing, 8)
                 
-                Text("\(memberNum)명의 멤버들이 함께하고 있어요.")
+                Text("\(viewModel.memberNum)명의 멤버들이 함께하고 있어요.")
                     .fontWithLineHeight(fontLevel: .body5)
             }
         }
@@ -167,7 +167,7 @@ extension InvitationView {
                     .foregroundStyle(.grayscaleWhite)
             }
         } else {
-            CustomAsyncImage(url: memberProfileUrls[index] ?? "",
+            CustomAsyncImage(url: viewModel.memberProfileImages[index] ?? "",
                              type: .postMemberProfileImage,
                              width: 29, height: 29)
             .clipShape(Circle())

--- a/Treehouse/Treehouse/Presentation/Auth/RegisterScene/ViewModels/UserSettingViewModel.swift
+++ b/Treehouse/Treehouse/Presentation/Auth/RegisterScene/ViewModels/UserSettingViewModel.swift
@@ -262,9 +262,9 @@ extension UserSettingViewModel {
             return false
         }
         
-        print(registerType, treehouseId, userName, memberName, bio, accessUrlImage.first ?? "")
+        let imageUrl = accessUrlImage.first ?? ""
         
-        let result = await registerTreeMemberUseCase.execute(registerType: registerType, requestDTO: PostRegisterTreeMemberRequestDTO(treehouseId: treehouseId, userName: userName, memberName: memberName, bio: bio, profileImageURL: accessUrlImage.first ?? "" ))
+        let result = await registerTreeMemberUseCase.execute(registerType: registerType, requestDTO: PostRegisterTreeMemberRequestDTO(treehouseId: treehouseId, userName: userName, memberName: memberName, bio: bio, profileImageURL: imageUrl))
         
         switch result {
         case .success(let response):

--- a/Treehouse/Treehouse/Presentation/Auth/RegisterScene/Views/SetMemberProfileImage.swift
+++ b/Treehouse/Treehouse/Presentation/Auth/RegisterScene/Views/SetMemberProfileImage.swift
@@ -60,14 +60,19 @@ struct SetMemberProfileImage: View {
             Spacer()
             
             Button(action: {
-                Task {
-                    if await viewModel.presignedURL() {
-                        await viewModel.loadImageAWS()
-                    }
-                }
-                
-                if viewModel.isPresignedURL == viewModel.isloadImageAWS {
+                if photoPickerManager.selectedImages.isEmpty {
+                    viewModel.accessUrlImage.append("")
                     viewRouter.push(RegisterRouter.setMemberBioView)
+                } else {
+                    Task {
+                        if await viewModel.presignedURL() {
+                            await viewModel.loadImageAWS()
+                        }
+                    }
+                    
+                    if viewModel.isPresignedURL == viewModel.isloadImageAWS {
+                        viewRouter.push(RegisterRouter.setMemberBioView)
+                    }
                 }
             }) {
                 Text(StringLiterals.Register.buttonTitle10)

--- a/Treehouse/Treehouse/Presentation/Feed/FeedScene/ViewModels/MyProfileViewModel.swift
+++ b/Treehouse/Treehouse/Presentation/Feed/FeedScene/ViewModels/MyProfileViewModel.swift
@@ -70,8 +70,8 @@ extension MyProfileViewModel {
         switch result {
         case .success(let response):
             myProfileData = response
-            isLoadedMyProfile.toggle()
-
+            isLoadedMyProfile = true
+            
             return false
         case .failure(let error):
             await MainActor.run {

--- a/Treehouse/Treehouse/Presentation/Profile/Views/MyProfileView.swift
+++ b/Treehouse/Treehouse/Presentation/Profile/Views/MyProfileView.swift
@@ -59,8 +59,21 @@ struct MyProfileView: View {
                                     )
                                 )
                             })
+                        } else {
+                            UserInfoView(infoType: .myProfile, 
+                                         treememberName: "",
+                                         userName: "",
+                                         profileImageUrl: "",
+                                         bio: "",
+                                         branchCount: 0,
+                                         treeHouseCount: 0,
+                                         root: "",
+                                         inviteAction: {},
+                                         branchAction: {},
+                                         profileAction: {})
+                                .redacted(reason: isLoading ? .placeholder : [])
                         }
-                    }.redacted(reason: isLoading ? .placeholder : [])
+                    }
                     
                     VStack(spacing: 0) {
                         SettingView(state: .aboutTreeHouse)
@@ -71,22 +84,22 @@ struct MyProfileView: View {
                 .padding(.top, 16)
             }
             .refreshable {
-                if let treehouseId = currentTreehouseInfoViewModel.currentTreehouseId {
-                    isLoading = await myProfileViewModel.readMyProfileInfo(treehouseId: treehouseId)
-                }
+                myProfileViewModel.myProfileData = nil
+                isLoading = await myProfileViewModel.readMyProfileInfo(treehouseId: selectedTreehouseId)
             }
         }
         .task {
             if myProfileViewModel.isLoadedMyProfile == false {
-                if let treehouseId = currentTreehouseInfoViewModel.currentTreehouseId {
-                    isLoading = await myProfileViewModel.readMyProfileInfo(treehouseId: treehouseId)
-                }
+                isLoading = true
+                myProfileViewModel.myProfileData = nil
+                isLoading = await myProfileViewModel.readMyProfileInfo(treehouseId: selectedTreehouseId)
             }
         }
         .onChange(of: selectedTreehouseId) { _, newValue in
+            isLoading = true
             myProfileViewModel.myProfileData = nil
             Task {
-                await myProfileViewModel.readMyProfileInfo(treehouseId: selectedTreehouseId)
+                isLoading = await myProfileViewModel.readMyProfileInfo(treehouseId: selectedTreehouseId)
             }
         }
         .customAlert(alertType: myProfileViewModel.isAlert.1,


### PR DESCRIPTION
## 📟 관련 이슈
- Resolved: #150 

<br>

## 👷 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
- `ReceivedFirstInvitaionView` 에서 초대장 데이터를 출력하지 못하는 오류 해결 ( 유저 이미지 index 에러 발생 )
- `SetMemberProfileImage` 에서 이미지를 선택하지 않아도 회원가입을 할 수 있게 변경
-  `MyProfileView` 에서 데이터가 로딩 됐지만 스켈레톤 UI 가 사라지지 않는 문제 해결

<br>

## 🚨 참고 사항
<!-- 참고 사항을 적어주세요. 없으면 지워주세요. -->
- 회원가입 후 Feed 가 로딩되지 않는 현상을 재현할 수 없어 다른 오류 사항을 변경했습니다.
- `ReceivedFirstInvitaionView` 에서 발생했던 요인은 ViewModel 과의 데이터 바인딩이 되어있지 않은 상황
    - ViewModel 과 바인딩을 하여 유저의 이미지 관련 index 오류를 해결
- `MyProfileView` 에서는 task 와 onChange 수정자로 인해 내 프로필 API 가 두번 요청되는 상황 발생 
    - onChange 수정자에서 스켈레톤 UI 를 없애는 isLoading 변수에 값을 할당하지 않아 사라지지 않음 -> 할당하여 문제 해결
    - 다만 계속 API 가 2번 요청되는 현상이 존재하고 Treehouse 가 변경될 때도 Myprofile 내용이 변해야하기 때문에 onChange 를 없앨 수 없음
    - 이부분에 대한 고민을 더 해서 고쳐야 할거 같습니다!

<br>

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
