### PR TITLE
[Fix] #152 - 이모지 반응 로직 변경

### DIFF
--- a/Treehouse/Treehouse/Presentation/Feed/FeedContentScene/Views/EmojiGridView.swift
+++ b/Treehouse/Treehouse/Presentation/Feed/FeedContentScene/Views/EmojiGridView.swift
@@ -66,7 +66,7 @@ struct EmojiGridView: View {
                         .frame(width:32, height: 32)
                     
                     
-                    TextField("이모티콘 검색", text: $serachEmoji)
+                    TextField("이모티콘 검색", text: $emojiViewModel.inputEmoji)
                         .padding(.vertical, 3)
                         .tint(.treeGreen)
                         .focused($focusedField)
@@ -75,13 +75,13 @@ struct EmojiGridView: View {
                 .padding(EdgeInsets(top: 0, leading: 10, bottom: 0, trailing: 10))
                 .fontWithLineHeight(fontLevel: .body3)
                 .foregroundStyle(.gray7)
-                .background(.gray3)
+                .background(.gray2)
                 .clipShape(RoundedRectangle(cornerRadius: 10.0))
                 .padding(.bottom, 17)
                 
                 ScrollView {
                     LazyVGrid(columns: columns, spacing: 20) {
-                        ForEach(emojiViewModel.emojis) { data in
+                        ForEach(emojiViewModel.emojiList) { data in
                             VStack {
                                 Button(action: {
                                     if self.selectedId == data.id {
@@ -121,8 +121,10 @@ struct EmojiGridView: View {
             }
             .padding(EdgeInsets(top: 0, leading: 17, bottom: 10, trailing: 16))
         }
-        .background(.gray2)
-        .selectCornerRadius(radius: 20, corners: [.topLeft, .topRight])
+        .background(.grayscaleWhite)
+        .selectCornerRadius(radius: 18, corners: [.topLeft, .topRight])
+        .padding(.top, 1)
+        .shadow(color: .gray6.opacity(0.7), radius: 20, x: 0, y: -10)
         .onTapGesture {
             selectedId = nil
             focusedField = false
@@ -163,10 +165,17 @@ extension EmojiGridView {
         Task {
             switch emojiType {
             case .feedView:
-                _ = await emojiViewModel.createReactionPost(
+                let result = await emojiViewModel.createReactionPost(
                     treehouseId: feedViewModel.currentTreehouseId ?? 0,
                     postId: postId ?? 0
                 )
+                
+                if result {
+                    feedViewModel.selectEmoji = emojiViewModel.selectEmoji
+                    feedViewModel.selectPostId = postId
+                    
+                    emojiViewModel.selectEmoji = nil
+                }
                 
             case .detailView:
                 _ = await emojiViewModel.createReactionComment(

--- a/Treehouse/Treehouse/Presentation/Feed/FeedScene/ViewModels/EmojiViewModel.swift
+++ b/Treehouse/Treehouse/Presentation/Feed/FeedScene/ViewModels/EmojiViewModel.swift
@@ -21,13 +21,16 @@ final class EmojiViewModel: BaseViewModel {
     
     // MARK: - Property
     
-    var emojis = [EmojiDatas]()
-    var selectEmoji: String? {
+    private var emojis = [EmojiDatas]()
+    var selectEmoji: String?
+    var errorMessage: String = ""
+    var inputEmoji: String = "" {
         didSet {
-            self.selectEmoji
+            searchEmoji()
         }
     }
-    var errorMessage: String = ""
+    
+    private(set) var emojiList = [EmojiDatas]()
     
     var feedEmojiData: ReactionListDataEntity? {
         didSet {
@@ -61,11 +64,20 @@ extension EmojiViewModel {
         do {
             let data = try Data(contentsOf: url)
             let decodeData = try JSONDecoder().decode([EmojiDatas].self, from: data)
-            DispatchQueue.main.async {
-                self.emojis = decodeData
-            }
+            
+            emojis = decodeData
+            emojiList = emojis
+            
         } catch {
             print("JSON 파일 디코딩 실패: \(error)")
+        }
+    }
+    
+    func searchEmoji() {
+        if inputEmoji.isEmpty {
+            emojiList = emojis
+        } else {
+            emojiList = emojis.filter { $0.unicodeEmoji == inputEmoji }
         }
     }
 }
@@ -84,9 +96,6 @@ extension EmojiViewModel {
         
         switch result {
         case .success(_):
-            await MainActor.run {
-                self.selectEmoji = nil
-            }
             
             return true
             
@@ -113,9 +122,7 @@ extension EmojiViewModel {
         
         switch result {
         case .success(_):
-            await MainActor.run {
-                self.selectEmoji = nil
-            }
+            self.selectEmoji = nil
             
             return true
             
@@ -129,3 +136,4 @@ extension EmojiViewModel {
         }
     }
 }
+

--- a/Treehouse/Treehouse/Presentation/Feed/FeedScene/ViewModels/FeedViewModel.swift
+++ b/Treehouse/Treehouse/Presentation/Feed/FeedScene/ViewModels/FeedViewModel.swift
@@ -26,6 +26,10 @@ final class FeedViewModel: BaseViewModel {
     
     /// Feed 의 Post 내용이 바뀌었을때 다시 내용을 로드하기 위한 변수
     var modifyPostContent: (Int, String) = (0, "")
+    var selectEmoji: String?
+    
+    @ObservationIgnored
+    var selectPostId: Int?
     
     @ObservationIgnored
     var currentTreehouseId: Int?

--- a/Treehouse/Treehouse/Presentation/Feed/FeedScene/Views/FeedHomeView.swift
+++ b/Treehouse/Treehouse/Presentation/Feed/FeedScene/Views/FeedHomeView.swift
@@ -80,6 +80,17 @@ struct FeedHomeView: View {
                 }
             }
         }
+        .sheet(isPresented: $feedViewModel.isSelectEmojiView) {
+            if let postId = feedViewModel.currentPostId {
+                EmojiGridView(emojiType: .feedView, postId: postId)
+                    .environment(feedViewModel)
+                    .environment(emojiViewModel)
+                    .presentationDetents([.fraction(0.98)])
+                    .presentationCornerRadius(20)
+                    .edgesIgnoringSafeArea(.bottom)
+            }
+        }
+
         .navigationBarHidden(true)
         .navigationDestination(for: FeedRouter.self) { router in
             viewRouter.buildScene(inputRouter: router, viewModel: feedViewModel)
@@ -113,6 +124,13 @@ struct FeedHomeView: View {
                 await MainActor.run {
                     self.postViewModel.isLoading = true
                 }
+            }
+        }
+        .onChange(of: feedViewModel.selectEmoji) { _, newValue in
+            guard let postId = feedViewModel.selectPostId, let emoji = newValue else { return }
+            
+            Task {
+                await postViewModel.changeEmojiData(postId: postId, selectEmoji: emoji)
             }
         }
     }

--- a/Treehouse/Treehouse/Presentation/Feed/FeedScene/Views/FeedView.swift
+++ b/Treehouse/Treehouse/Presentation/Feed/FeedScene/Views/FeedView.swift
@@ -58,27 +58,6 @@ struct FeedView: View {
                 emptyFeedView
             }
         }
-        .popup(isPresented: $feedViewModel.isSelectEmojiView) {
-            if let postId = feedViewModel.currentPostId {
-                EmojiGridView(emojiType: .feedView, postId: postId)
-                    .environment(feedViewModel)
-                    .environment(emojiViewModel)
-            }
-        } customize: {
-            $0
-                .type(.toast)
-                .closeOnTapOutside(true)
-                .dragToDismiss(true)
-                .isOpaque(true)
-                .backgroundColor(.treeBlack.opacity(0.5))
-        }
-        .onChange(of: feedViewModel.isSelectEmojiView) { _, newValue in
-            if newValue == false {
-                Task {
-                    _ = await postViewModel.readFeedPostsList(treehouseId: feedViewModel.currentTreehouseId ?? 0)
-                }
-            }
-        }
         .onChange(of: focusedField) { _, newValue in
             if newValue == .post {
                 textFieldState = .enable

--- a/Treehouse/Treehouse/Presentation/Feed/FeedScene/Views/PostDetailView.swift
+++ b/Treehouse/Treehouse/Presentation/Feed/FeedScene/Views/PostDetailView.swift
@@ -124,33 +124,25 @@ struct PostDetailView: View {
                     .foregroundStyle(.treeBlack)
             }
         }
-        .popup(isPresented: $emojiViewModel.isSelectFeedEmojiView) {
+        .sheet(isPresented: $emojiViewModel.isSelectFeedEmojiView) {
             if let postId = feedViewModel.currentPostId {
                 EmojiGridView(emojiType: .feedView, postId: postId)
                     .environment(feedViewModel)
                     .environment(emojiViewModel)
+                    .presentationDetents([.fraction(0.98)])
+                    .presentationCornerRadius(20)
+                    .edgesIgnoringSafeArea(.bottom)
             }
-        } customize: {
-            $0
-                .type(.toast)
-                .closeOnTapOutside(true)
-                .dragToDismiss(true)
-                .isOpaque(true)
-                .backgroundColor(.treeBlack.opacity(0.5))
         }
-        .popup(isPresented: $emojiViewModel.isSelectCommentEmojiView) {
+        .sheet(isPresented: $emojiViewModel.isSelectCommentEmojiView) {
             if feedViewModel.currentPostId != nil {
                 EmojiGridView(emojiType: .detailView, commentId: feedViewModel.currentCommentId ?? 0)
                     .environment(feedViewModel)
                     .environment(emojiViewModel)
+                    .presentationDetents([.fraction(0.98)])
+                    .presentationCornerRadius(20)
+                    .edgesIgnoringSafeArea(.bottom)
             }
-        } customize: {
-            $0
-                .type(.toast)
-                .closeOnTapOutside(true)
-                .dragToDismiss(true)
-                .isOpaque(true)
-                .backgroundColor(.treeBlack.opacity(0.5))
         }
         .onAppear {
             Task {


### PR DESCRIPTION
## 📟 관련 이슈
- Resolved: #152

<br>

## 👷 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
- EmojiGridView 를 띄우는 로직을 SwiftUI 의 Sheet 수정자로 로직 변경
- EmojiGridView 에서 Emoji 검색 기능 구현
- 이모지 반응 시 Feed 의 게시글을 업데이트 하는 로직 변경

<br>

## 🚨 참고 사항
<!-- 참고 사항을 적어주세요. 없으면 지워주세요. -->
- `EmojiGridView` 를 띄우는 로직을 SwiftUI 의 Sheet 수정자로 로직 변경
    - `EmojiGridView` 를 띄울 떄 PopupView 라이브러리를 통해서 구현되어있습니다
    - 다만, keyboard 를 띄우거나 스크롤 할때 부자연스러운 애니메이션에 대한 문제가 있었습니다.
    - SwiftUI 시스템에서 사용하는 sheet 수정자로 변경하여 이모지 검색 시 Keyboard 가 올라오는 문제를 해결할 수 있었습니다

<br>

- 이모지 반응 시 Feed 의 게시글을 업데이트 하는 로직 변경
    - Feed 에서 이모지 반응 시 업데이트 하기 위해서 게시글을 다시 불러오는 로직으로 되어있었습니다.
    - 페이지네이션으로 하단까지 내려가있는 상황에서 이모지를 눌렀을 때 기존 글이 없어지는 문제가 있었습니다.
    - 이모지 반응을 서버에 보내는 건 동일하지만 다시 불러오지 않고 기존 데이터를 변경하는 로직으로 바꿨습니다.

<br>

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
