### PR TITLE
[Fix] #154 - 게시글 삭제 및 수정 로직 및 마이 페이지 버튼 로직 수정

### DIFF
--- a/Treehouse/Treehouse.xcodeproj/project.pbxproj
+++ b/Treehouse/Treehouse.xcodeproj/project.pbxproj
@@ -208,6 +208,7 @@
 		3FE00F0E2BC6D35A00CC821E /* SetUserIdView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FE00F0D2BC6D35A00CC821E /* SetUserIdView.swift */; };
 		3FE00F102BC7E29700CC821E /* TextFieldStateType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FE00F0F2BC7E29700CC821E /* TextFieldStateType.swift */; };
 		3FE00F122BC8138300CC821E /* ShowUserProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FE00F112BC8138300CC821E /* ShowUserProfileView.swift */; };
+		3FE0DD712CA5778100002176 /* DeleteFeedPostUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FE0DD702CA5778100002176 /* DeleteFeedPostUseCase.swift */; };
 		3FE6B7F42C7EEBFD00457DD0 /* PostInvitationRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FE6B7F32C7EEBFD00457DD0 /* PostInvitationRequestDTO.swift */; };
 		3FE6B7F62C7EECD800457DD0 /* PostInvitationResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FE6B7F52C7EECD700457DD0 /* PostInvitationResponseDTO.swift */; };
 		3FE6B7F82C7EED6900457DD0 /* InvitationResponseEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FE6B7F72C7EED6900457DD0 /* InvitationResponseEntity.swift */; };
@@ -521,6 +522,7 @@
 		3FE00F0D2BC6D35A00CC821E /* SetUserIdView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetUserIdView.swift; sourceTree = "<group>"; };
 		3FE00F0F2BC7E29700CC821E /* TextFieldStateType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFieldStateType.swift; sourceTree = "<group>"; };
 		3FE00F112BC8138300CC821E /* ShowUserProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShowUserProfileView.swift; sourceTree = "<group>"; };
+		3FE0DD702CA5778100002176 /* DeleteFeedPostUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteFeedPostUseCase.swift; sourceTree = "<group>"; };
 		3FE6B7F32C7EEBFD00457DD0 /* PostInvitationRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PostInvitationRequestDTO.swift; path = Treehouse/Domain/UseCases/Register/PostInvitationRequestDTO.swift; sourceTree = SOURCE_ROOT; };
 		3FE6B7F52C7EECD700457DD0 /* PostInvitationResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostInvitationResponseDTO.swift; sourceTree = "<group>"; };
 		3FE6B7F72C7EED6900457DD0 /* InvitationResponseEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvitationResponseEntity.swift; sourceTree = "<group>"; };
@@ -1300,6 +1302,7 @@
 				3F8530EF2C5639E3003FA07A /* CreateReactionToPostUseCase.swift */,
 				3F8AE7052C59E11D00E999C4 /* CreateFeedPostsUseCase.swift */,
 				3F8AE7112C5A2C1100E999C4 /* UpdateFeedPostUseCase.swift */,
+				3FE0DD702CA5778100002176 /* DeleteFeedPostUseCase.swift */,
 			);
 			path = Feed;
 			sourceTree = "<group>";
@@ -2053,6 +2056,7 @@
 				3F06C3072BFDEB40002B771B /* PostReactionCommentRequestDTO.swift in Sources */,
 				3FEC57672C8F48630080DF96 /* PostRegisterPushAgreeResponseDTO.swift in Sources */,
 				3FEC57632C8F28B80080DF96 /* MemberBranchView.swift in Sources */,
+				3FE0DD712CA5778100002176 /* DeleteFeedPostUseCase.swift in Sources */,
 				3F1936142C6287B600584939 /* PostCheckNotificationsResponseDTO.swift in Sources */,
 				3FA175E32C1AC47A00A57987 /* PresignedURLResponseEntity.swift in Sources */,
 				3F06C2FA2BFDC2E8002B771B /* FeedAPI.swift in Sources */,

--- a/Treehouse/Treehouse/Data/Repositories/FeedRepositoryImpl.swift
+++ b/Treehouse/Treehouse/Data/Repositories/FeedRepositoryImpl.swift
@@ -93,4 +93,16 @@ final class FeedRepositoryImpl: FeedRepositoryProtocol {
             return .failure(NetworkError.unknown)
         }
     }
+    
+    /// 내 게시글을 삭제하는 API
+    func deleteFeedPost(treehouseId: Int, postId: Int) async -> Result<Void, NetworkError> {
+        do {
+            let response = try await feedService.deleteFeedPost(treehouseId: treehouseId, postId: postId)
+            return .success(())
+        } catch let error as NetworkError {
+            return .failure(error)
+        } catch {
+            return .failure(NetworkError.unknown)
+        }
+    }
 }

--- a/Treehouse/Treehouse/Domain/RepositoryProtocol/FeedRepositoryProtocol.swift
+++ b/Treehouse/Treehouse/Domain/RepositoryProtocol/FeedRepositoryProtocol.swift
@@ -15,4 +15,5 @@ protocol FeedRepositoryProtocol {
     func patchUpdateFeedPost(treehouseId: Int, postId: Int, context: String) async -> Result<UpdateFeedPostResponseEntity, NetworkError>
     func getReadDetailPost(treehouseId: Int, postId: Int) async -> Result<GetReadDetailFeedPostResponseEntity, NetworkError>
     func postCreateReactionToPost(treehouseId: Int, postId: Int, requestDTO: PostReactionFeedPostRequestDTO) async -> Result<String, NetworkError>
+    func deleteFeedPost(treehouseId: Int, postId: Int) async -> Result<Void, NetworkError>
 }

--- a/Treehouse/Treehouse/Domain/UseCases/Feed/DeleteFeedPostUseCase.swift
+++ b/Treehouse/Treehouse/Domain/UseCases/Feed/DeleteFeedPostUseCase.swift
@@ -1,0 +1,25 @@
+//
+//  DeleteFeedPostUseCase.swift
+//  Treehouse
+//
+//  Created by ParkJunHyuk on 9/26/24.
+//
+
+import Foundation
+
+protocol DeleteFeedPostUseCaseProtocol {
+    func execute(treehouseId: Int, postId: Int) async -> Result<Void, NetworkError>
+}
+
+final class DeleteFeedPostUseCase: DeleteFeedPostUseCaseProtocol {
+    private let repository: FeedRepositoryProtocol
+    
+    init(repository: FeedRepositoryProtocol) {
+        self.repository = repository
+    }
+    
+    func execute(treehouseId: Int, postId: Int) async -> Result<Void, NetworkError> {
+        return await repository.deleteFeedPost(treehouseId: treehouseId, postId: postId)
+    }
+}
+

--- a/Treehouse/Treehouse/Global/Components/CustomAlertView.swift
+++ b/Treehouse/Treehouse/Global/Components/CustomAlertView.swift
@@ -9,18 +9,36 @@ import SwiftUI
 
 struct CustomAlertView: View {
     
+    @Binding var isPresented: Bool
     var alertType: AlertType
     var onCancel: () -> Void
-    var onConfirm: () -> Void
+    var onConfirm: (@escaping () -> Void) -> Void
     
     var body: some View {
-        VStack(spacing: 41) {
-            Text(alertType.title)
-                .fontWithLineHeight(fontLevel: .heading4)
-            
+        VStack {
+            VStack(spacing: 41) {
+                Text(alertType.title)
+                    .fontWithLineHeight(fontLevel: .heading4)
+                
+                bottomButtonSection
+            }
+            .padding(EdgeInsets(top: 49.0, leading: 14.0, bottom: 14.0, trailing: 14.0))
+            .background(.gray1)
+            .clipShape(RoundedRectangle(cornerRadius: 12.0))
+            .padding(.horizontal, 14)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(.treeBlack.opacity(0.5))
+    }
+    
+    @ViewBuilder
+    var bottomButtonSection: some View {
+        switch alertType {
+        case .logout, .deleteAccount:
             HStack(spacing: 12) {
                 Button(action: {
                     onCancel()
+                    isPresented.toggle()
                 }) {
                     Text("취소")
                         .fontWithLineHeight(fontLevel: .body3)
@@ -35,7 +53,9 @@ struct CustomAlertView: View {
                 .cornerRadius(8)
                 
                 Button(action: {
-                    onConfirm()
+                    onConfirm {
+                        isPresented.toggle()
+                    }
                 }) {
                     Text("확인")
                         .fontWithLineHeight(fontLevel: .body3)
@@ -46,24 +66,37 @@ struct CustomAlertView: View {
                 }
                 .clipShape(RoundedRectangle(cornerRadius: 8.0))
             }
+        case .deletePost, .error:
+            Button(action: {
+                onConfirm {
+//                    isPresented.toggle()
+                }
+            }) {
+                Text("확인")
+                    .fontWithLineHeight(fontLevel: .body3)
+                    .foregroundStyle(.grayscaleWhite)
+                    .padding(.vertical, 11)
+                    .frame(maxWidth: .infinity)
+                    .background(.grayscaleBlack)
+                    .border(.black)
+            }
+            .clipShape(RoundedRectangle(cornerRadius: 8.0))
         }
-        .padding(EdgeInsets(top: 49.0, leading: 14.0, bottom: 14.0, trailing: 14.0))
-        .background(.gray1)
-        .clipShape(RoundedRectangle(cornerRadius: 12.0))
     }
 }
 
-#Preview {
-    CustomAlertView(alertType: .logout, 
-                    onCancel: {},
-                    onConfirm: {}
-                )
-}
-
+//#Preview {
+//    CustomAlertView(alertType: .logout, 
+//                    onCancel: {},
+//                    onConfirm: {}
+//                )
+//}
 
 enum AlertType {
     case logout
     case deleteAccount
+    case deletePost(result: ActionResult?)
+    case error
     
     var title: String {
         switch self {
@@ -71,6 +104,17 @@ enum AlertType {
             return "로그아웃을 하시겠습니까?"
         case .deleteAccount:
             return "정말로 회원탈퇴를 하시겠습니까?"
+        case .deletePost(let result):
+            switch result {
+            case .success:
+                return "게시글을 삭제했습니다"
+            case .failure:
+                return "오류가 발생했습니다"
+            case .none:
+                return ""
+            }
+        case .error:
+            return "알수 없는 오류가 발생했습니다"
         }
     }
 }

--- a/Treehouse/Treehouse/Global/Extension/View+.swift
+++ b/Treehouse/Treehouse/Global/Extension/View+.swift
@@ -160,12 +160,13 @@ extension View {
         self
             .fullScreenCover(isPresented: isPresented) {
                 CustomAlertView(
+                    isPresented: isPresented, 
                     alertType: alertType,
                     onCancel: {
                         onCancel()
                         isPresented.wrappedValue = false
                     },
-                    onConfirm: {
+                    onConfirm: { _ in
                         onConfirm()
                         isPresented.wrappedValue = false
                     }

--- a/Treehouse/Treehouse/Network/Feed/FeedService.swift
+++ b/Treehouse/Treehouse/Network/Feed/FeedService.swift
@@ -56,15 +56,15 @@ final class FeedService {
     }
     
     /// Feed 의 게시글을 삭제하는 API
-//    func deleteFeedPost(treehouseId: Int, postId: Int) async throws -> BaseResponse<nil> {
-//        let request = NetworkRequest(requestType: FeedAPI.getReadFeedPostsList(treehouseId: treehouseId))
-//        
-//        guard let urlRequest = request.request() else {
-//            throw NetworkError.clientError(message: "Request 생성불가")
-//        }
-//        
-//        return try await networkServiceManager.performRequest(with: urlRequest, decodingType: GetReadFeedPostsListResponseDTO.self)
-//    }
+    func deleteFeedPost(treehouseId: Int, postId: Int) async throws -> Empty {
+        let request = NetworkRequest(requestType: FeedAPI.deleteFeedPost(treehouseId: treehouseId, postId: postId))
+        
+        guard let urlRequest = request.request() else {
+            throw NetworkError.clientError(message: "Request 생성불가")
+        }
+        
+        return try await networkServiceManager.performRequest(with: urlRequest, decodingType: Empty.self)
+    }
     
     /// Feed 의 게시글을 수정하는 API
     func patchUpdateFeedPost(treehouseId: Int, postId: Int, context: String) async throws -> PatchUpdateFeedPostResponseDTO {

--- a/Treehouse/Treehouse/Presentation/Feed/FeedScene/ViewModels/MyProfileViewModel.swift
+++ b/Treehouse/Treehouse/Presentation/Feed/FeedScene/ViewModels/MyProfileViewModel.swift
@@ -22,7 +22,10 @@ final class MyProfileViewModel: BaseViewModel {
     var myProfileData: ReadMyProfileInfoResponseEntity?
     var isLoadedMyProfile = false
     var isDeleteUser = false
-    var isAlert: (Bool, AlertType) = (false, .logout)
+    var isPresentedAlert: Bool = false
+    
+    var presentedAlertType: AlertType?
+    
     var isWebViewPresented = false
     var webViewUrl = ""
     var errorMessage: String = ""
@@ -36,30 +39,32 @@ final class MyProfileViewModel: BaseViewModel {
         self.deleteUserUseCase = deleteUserUseCase
     }
     
-    func buttonAction(titleName: String) {
+    func settingListButtonAction(titleName: String) {
         switch titleName {
         case "운영정책":
             isWebViewPresented.toggle()
             webViewUrl = "https://sites.google.com/view/treehouse-manage/%ED%99%88"
+            
         case "개인정보정책":
             isWebViewPresented.toggle()
             webViewUrl = "https://sites.google.com/view/treehouse-privacy/%ED%99%88"
+            
         case "로그아웃 하기":
-            isAlert.0.toggle()
-            isAlert.1 = .logout
-            
-            KeychainHelper.shared.delete(for: Config.accessTokenKey)
-            KeychainHelper.shared.delete(for: Config.refreshTokenKey)
-            
+            isPresentedAlert.toggle()
+            presentedAlertType = .logout
+
         case "회원탈퇴 하기":
-            isAlert.0.toggle()
-            
-            KeychainHelper.shared.delete(for: Config.accessTokenKey)
-            KeychainHelper.shared.delete(for: Config.refreshTokenKey)
-            
+            isPresentedAlert.toggle()
+            presentedAlertType = .deleteAccount
+
         default:
             break
         }
+    }
+    
+    func deleteServerToken() {
+        KeychainHelper.shared.delete(for: Config.accessTokenKey)
+        KeychainHelper.shared.delete(for: Config.refreshTokenKey)
     }
 }
 

--- a/Treehouse/Treehouse/Presentation/Feed/FeedScene/ViewModels/SheetActionViewModel.swift
+++ b/Treehouse/Treehouse/Presentation/Feed/FeedScene/ViewModels/SheetActionViewModel.swift
@@ -9,6 +9,11 @@ import Foundation
 import SwiftUI
 import Observation
 
+enum ActionResult {
+    case success
+    case failure
+}
+
 @Observable
 final class SheetActionViewModel: BaseViewModel {
     
@@ -20,10 +25,18 @@ final class SheetActionViewModel: BaseViewModel {
     var isDeleteCommentPopupShwing: Bool = false
     var isReportCommentPopupShwing: Bool = false
     
+    var isCompleteDeletePost: Bool = false
+    var deletePostReulst: ActionResult?
+    
     var isCompleteDeleteComment: Bool = false
     var isCompleteReportComment: Bool = false
     
-    var sheetCase: FeedBottomSheetCase = .isWriterOnPost
+    
+    var sheetCase: FeedBottomSheetCase = .isWriterOnPost {
+        didSet {
+            injectionUseCase()
+        }
+    }
     var postContent: String = ""
     
     var treehouseId: Int?
@@ -34,16 +47,32 @@ final class SheetActionViewModel: BaseViewModel {
     // MARK: - UseCase Property
     
     @ObservationIgnored
-    private let deleteCommentUseCase: DeleteCommentUseCaseProtocol?
+    private var deleteCommentUseCase: DeleteCommentUseCaseProtocol?
     
     @ObservationIgnored
-    private let reportCommentUseCase: PostReportCommentUseCaseProtocol?
+    private var reportCommentUseCase: PostReportCommentUseCaseProtocol?
+    
+    @ObservationIgnored
+    private var deleteFeedPostUseCase: DeleteFeedPostUseCaseProtocol?
     
     // MARK: - init
     
-    init(deleteCommentUseCase: DeleteCommentUseCaseProtocol? = nil, reportCommentUseCase: PostReportCommentUseCaseProtocol? = nil) {
+    init(deleteCommentUseCase: DeleteCommentUseCaseProtocol? = nil, 
+         reportCommentUseCase: PostReportCommentUseCaseProtocol? = nil,
+         deleteFeedPostUseCase: DeleteFeedPostUseCaseProtocol? = nil
+    ) {
         self.deleteCommentUseCase = deleteCommentUseCase
         self.reportCommentUseCase = reportCommentUseCase
+        self.deleteFeedPostUseCase = deleteFeedPostUseCase
+    }
+    
+    func injectionUseCase() {
+        switch sheetCase {
+        case .isWriterOnPost:
+            deleteFeedPostUseCase = DeleteFeedPostUseCase(repository: FeedRepositoryImpl())
+        default:
+            break
+        }
     }
     
     func handleSheetAction(_ action: String) {
@@ -57,6 +86,23 @@ final class SheetActionViewModel: BaseViewModel {
             // TODO: - 포스트 삭제하기 액션
             print("포스트 삭제하기")
             isDeletePostPopupShowing = true
+            
+            if let treehouseId = treehouseId, let postId = postId {
+                Task {
+                    let result = await deleteFeedPostUseCase?.execute(treehouseId: treehouseId, postId: postId)
+                    isBottomSheetShowing.toggle()
+                    
+                    switch result {
+                    case .success:
+                        isCompleteDeletePost = true
+                        deletePostReulst = .success
+                    case .failure(_):
+                        deletePostReulst = .failure
+                    case .none:
+                        break
+                    }
+                }
+            }
             
         case "reportPost":
             // TODO: - 신고하기 액션
@@ -74,7 +120,7 @@ final class SheetActionViewModel: BaseViewModel {
                     switch result {
                     case .success:
                         isCompleteDeleteComment = true
-                    case .failure(let error):
+                    case .failure(_):
                         break
                     case .none:
                         break
@@ -91,7 +137,7 @@ final class SheetActionViewModel: BaseViewModel {
                     case .success:
                         isCompleteReportComment = true
                         
-                    case .failure(let error):
+                    case .failure(_):
                         break
                     case .none:
                         break

--- a/Treehouse/Treehouse/Presentation/Feed/FeedScene/Views/EditPostPopupView.swift
+++ b/Treehouse/Treehouse/Presentation/Feed/FeedScene/Views/EditPostPopupView.swift
@@ -18,6 +18,7 @@ struct EditPostPopupView: View {
     
     @State private var isCancelPopupShowing: Bool = false
     @State var postContent: String
+    @FocusState private var isFocused: Bool
     
     // MARK: - Property
     
@@ -46,9 +47,17 @@ struct EditPostPopupView: View {
                                 .fontWithLineHeight(fontLevel: .body2)
                                 .foregroundStyle(.treeBlack)
                                 .padding(.bottom, 2)
-                            
-                            DynamicHeightTextEditorView(text: $postContent)
-                                .padding(.bottom, 8)
+
+                            TextEditor(text: $postContent)
+                                .fontWithLineHeight(fontLevel: .body3)
+                                .focused($isFocused)
+                                .onAppear {
+                                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                                        self.isFocused = true
+                                    }
+                                }
+                                .padding(.bottom, 15)
+                                .zIndex(1)
 
                             
                             if postImageURLs.count == 1 {
@@ -82,8 +91,9 @@ struct EditPostPopupView: View {
                 cancleEditPopupView
             }
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(Color.white)
+        .onAppear {
+            UIApplication.shared.hideKeyboard()
+        }
     }
 }
 
@@ -92,6 +102,7 @@ extension EditPostPopupView {
     var editPostPopupHeaderView: some View {
         HStack(alignment: .center) {
             Button(action: {
+                hideKeyboard()
                 self.isCancelPopupShowing.toggle()
             }) {
                 Text("취소")
@@ -110,6 +121,7 @@ extension EditPostPopupView {
             Spacer()
             
             Button(action: {
+                hideKeyboard()
                 Task {
                     await updateFeedPostViewModel.updateFeedPost(treehouseId: feedViewModel.currentTreehouseId ?? 0, postId: postId, context: postContent)
                     

--- a/Treehouse/Treehouse/Presentation/Feed/FeedScene/Views/SinglePostView.swift
+++ b/Treehouse/Treehouse/Presentation/Feed/FeedScene/Views/SinglePostView.swift
@@ -106,6 +106,9 @@ struct SinglePostView: View {
                                     viewModel.sheetCase = .isReaderOnPost
                                 }
                                 
+                                viewModel.treehouseId = feedViewModel.currentTreehouseId
+                                viewModel.postId = postId
+                                
                                 viewModel.isBottomSheetShowing.toggle()
                             }) {
                                 Image(.icMeatball)
@@ -154,6 +157,17 @@ struct SinglePostView: View {
                 .isOpaque(true)
                 .closeOnTap(false)
                 .backgroundColor(.treeBlack.opacity(0.5))
+        }
+        .topLevelAlert(isPresented: $viewModel.isCompleteDeletePost) {
+            CustomAlertView(
+                isPresented: $viewModel.isCompleteDeletePost,
+                alertType: .deletePost(result: viewModel.deletePostReulst),
+                onCancel: {},
+                onConfirm: { completion in
+                    viewModel.isCompleteDeletePost = false
+                    completion()
+                }
+            )
         }
     }
 }

--- a/Treehouse/Treehouse/Presentation/Profile/Views/SettingView.swift
+++ b/Treehouse/Treehouse/Presentation/Profile/Views/SettingView.swift
@@ -54,7 +54,7 @@ struct SettingView: View {
             
             ForEach(settingList, id: \.self) { settingOption in
                 Button(action: {
-                    myProfileViewModel.buttonAction(titleName: settingOption)
+                    myProfileViewModel.settingListButtonAction(titleName: settingOption)
                 }) {
                     Text(settingOption)
                         .fontWithLineHeight(fontLevel: .body2)


### PR DESCRIPTION
## 📟 관련 이슈
- Resolved: #154 

<br>

## 👷 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
- 게시글 삭제 관련 API 구현 및 Alert 추가
    - 게시글 삭제 후 완료되었다는 Alert 로직을 추가

- `MyProfileView` 의 로그아웃, 회원 탈퇴 시 사용하는 View 수정
    - Alert 이 나오고 취소 했을 때 `fullScreenCover` 수정자의 애니메이션을 동작하지 않도록 구현
    - Alert 에서 확인을 누르지 않더라도 KeyChain 에 저장된 Token 을 없애는 로직을 확인 버튼 후 실행되도록 변경
    
- Feed 에서 게시글 수정 관련 로직 수정
    - 게시글 수정하기 위한 바텀 시트가 올라오면 바로 키보드가 올라오게 설정
    - `TextEditor` 를 눌러도 반응이 없었던 문제를 해결 ( 하단 Image 의 영역 침범 )

<br>

## 📸 스크린샷

- 이전 MyProfileView 로그아웃, 회원탈퇴 

https://github.com/user-attachments/assets/0a646cce-65f8-4195-91b1-a2fdb84a07f7

- 수정한 MyProfileView 로그아웃, 회원탈퇴 

https://github.com/user-attachments/assets/83d40801-260a-4ee8-9c92-924fa13e3391

<br>

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
