### PR TITLE
[Fix] #156 - 전화번호 인증 제한 시 Alert 문구 변경

### DIFF
--- a/Treehouse/Treehouse/Presentation/Auth/RegisterScene/ViewModels/UserSettingViewModel.swift
+++ b/Treehouse/Treehouse/Presentation/Auth/RegisterScene/ViewModels/UserSettingViewModel.swift
@@ -416,7 +416,7 @@ extension UserSettingViewModel {
             
             switch error.code {
             case 17010:
-                isSendAuthMessageState = .error(title: "잦은 요청으로 인해 차단되었습니다\n1시간 후 다시 시도해주세요")
+                isSendAuthMessageState = .error(title: "인증 시도 횟수가 초과되었습니다\n일정 시간 후 다시 시도해주세요")
             default:
                 isSendAuthMessageState = .error(title: "알 수 없는 오류가 발생했습니다\n잠시 후 시도해주세요")
             }


### PR DESCRIPTION
## 📟 관련 이슈
- Resolved: #156 

<br>

## 👷 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
- 인증 제한시 Alert 의 문구를 수정했습니다. 

<br>

## 📸 스크린샷
|기능|변경 전|변경 후|
|:--:|:--:|:--:|
|GIF|<img src = "https://github.com/user-attachments/assets/6847b1ba-64fe-4809-9d34-fe5b9c6e4d54" width ="250">|<img src = "https://github.com/user-attachments/assets/2b79e42c-3654-4d03-8a8d-e8ad91b64108" width ="250">|

<br>

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
