### PR TITLE
[Refactor] #157 - Feed 에서 스크롤 시 메모리 사용량 증가 현상 해결

### DIFF
--- a/Treehouse/Treehouse/Presentation/Feed/FeedScene/Views/ImageDetailCarouselView.swift
+++ b/Treehouse/Treehouse/Presentation/Feed/FeedScene/Views/ImageDetailCarouselView.swift
@@ -12,8 +12,9 @@ struct ImageDetailCarouselView: View {
     // MARK: - State Property
     
     @Environment(\.presentationMode) var presentationMode
-    @State var selectedIndex: Int
-    @Binding var images: [(Int,UIImage)]
+    @Binding var selectedIndex: Int
+    
+    let imageUrls: [String]
     
     // MARK: - View
     
@@ -29,29 +30,24 @@ struct ImageDetailCarouselView: View {
                 .padding(.leading, 14)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 
-                Text("\(selectedIndex + 1) / \(images.count)")
+                Text("\(selectedIndex + 1) / \(imageUrls.count)")
                     .fontWithLineHeight(fontLevel: .body2)
                     .foregroundStyle(.grayscaleWhite)
                     .frame(maxWidth: .infinity)
             }
             
             TabView(selection: $selectedIndex) {
-                ForEach(0..<images.count, id: \.self) { imageIndex in
-                    Image(uiImage: images[imageIndex].1)
-                        .resizable()
-                        .aspectRatio(contentMode: .fit)
-                        .padding(.horizontal, 5)
-                        .frame(maxWidth:.infinity)
-                        .padding(.bottom, 30)
-                        .tag(imageIndex)
+                ForEach(0..<imageUrls.count, id: \.self) { imageIndex in
+                    CustomAsyncImage(url: imageUrls[imageIndex],
+                                     type: .carouselImage)
+                    .padding(.horizontal, 5)
+                    .padding(.bottom, 30)
+                    .tag(imageIndex)
                 }
             }
         }
         .background(.grayscaleBlack)
         .tabViewStyle(PageTabViewStyle(indexDisplayMode: .never))
-        .onAppear {
-            images = images.sorted(by: {$0.0 < $1.0} )
-        }
         .gesture(
             DragGesture()
                 .onEnded { value in
@@ -65,6 +61,6 @@ struct ImageDetailCarouselView: View {
 
 // MARK: - Preview
 
-//#Preview {
-//    ImageDetailCarouselView(images: [], selectedIndex: 1)
-//}
+#Preview {
+    ImageDetailCarouselView(selectedIndex: .constant(0), imageUrls:[""])
+}

--- a/Treehouse/Treehouse/Presentation/Feed/FeedScene/Views/SinglePostView.swift
+++ b/Treehouse/Treehouse/Presentation/Feed/FeedScene/Views/SinglePostView.swift
@@ -23,11 +23,9 @@ struct SinglePostView: View {
     
     @Environment (ViewRouter.self) var viewRouter
     @Environment (FeedViewModel.self) var feedViewModel
-    
-    @State private var selectedImage: Int? = nil
     @State private var viewModel = SheetActionViewModel()
     
-    @State private var loadedImage = [(Int,UIImage)]()
+    @State private var selectedImage = 0
     @State private var isDetailImage = false
     
     // MARK: - Property
@@ -127,7 +125,7 @@ struct SinglePostView: View {
                 contentImageView()
             }
             .fullScreenCover(isPresented: $isDetailImage) {
-                ImageDetailCarouselView(selectedIndex: selectedImage ?? 0, images: $loadedImage)
+                ImageDetailCarouselView(selectedIndex: $selectedImage, imageUrls: postImageURLs)
             }
         }
         // 바텀시트 표출
@@ -189,11 +187,10 @@ extension SinglePostView {
         CustomAsyncImage(url: postImageURLs.first ?? "",
                          type: .postImage,
                          width: 314,
-                         height: 200) { image in
-                            self.loadedImage.append((0, image))
-                        }
+                         height: 200)
             .onTapGesture {
                 if postType == .DetailView {
+                    selectedImage = 0
                     isDetailImage.toggle()
                 } else {
                     feedViewModel.currentPostId = postId
@@ -211,13 +208,11 @@ extension SinglePostView {
                 ForEach(0..<postImageURLs.count, id: \.self) { index in
                     CustomAsyncImage(url: postImageURLs[index], type: .postImage,
                                      width: 206,
-                                     height: 200) { image in
-                                        self.loadedImage.append((index, image))
-                                    }
+                                     height: 200)
                         .onTapGesture {
                             if postType == .DetailView {
-                                isDetailImage.toggle()
                                 selectedImage = index
+                                isDetailImage.toggle()
                             } else {
                                 feedViewModel.currentPostId = postId
                                 viewRouter.push(FeedRouter.postDetailView)


### PR DESCRIPTION
## 📟 관련 이슈
- Resolved: #157 

<br>

## 👷 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
- Image 를 받아오는 `ImageLoader` 의 구조 변경
- `ImageDetailCarouselView` 를 위해 클로저로 로딩 된 Image 를 바인딩 하는 구조를 변경

<br>

## 📸 스크린샷
|기능|변경 전|변경 후|
|:--:|:--:|:--:|
|Img|<img src = "https://github.com/user-attachments/assets/fe473186-6de5-460c-aee6-db495f2e8373" width ="350">|<img src = "https://github.com/user-attachments/assets/f109d29d-b710-4b02-9de9-f6c1462f251f" width ="350">|

<br>

## 🚨 참고 사항
<!-- 참고 사항을 적어주세요. 없으면 지워주세요. -->

위의 스크린샷 을 보게 되면 처음부터 끝까지 Feed 에 있는 게시글(사진 10장)을 대략 30 번 스크롤 한 상황의 메모리 사용량입니다.
참고로 사진은 서버에 올릴때 3MB 이하로 다운샘플링을 걸친 사진들로 되어있습니다.

스크롤을 할때마다 계속 메모리가 증가가 되는 현상을 발견하게 되었고 메모리 사용량을 줄이기 위해 Instruments 를 사용하여 분석을 해보았습니다. 

|기능|변경 전|변경 후|
|:--:|:--:|:--:|
|Img|<img src = "https://github.com/user-attachments/assets/896e56de-6442-4352-a00a-df835bb68e8f" width ="350">|<img src = "https://github.com/user-attachments/assets/91ab4b6c-5125-4c1b-afc1-93c253b38e48" width ="350">|

`VM: ImageIO_PNG_Data` 라는 항목에 메모리가 계속 증가하는 것을 찾았고 `Image` 나 `UIImage` 에서 이미지를 보여주기 위해 `ImageIO` 를 사용하는건가 라는 가정을 하게 되었습니다.

해당 가정에 대한 근거를 찾고자 직접 만든 `customAsyncImage` 컴포넌트와 이미지를 받아오는 `ImageLoader` 를 분석하게 되었고 `UImage` 유형의 데이터를 `ImageLoader` 가 갖고 있어서 메모리에서 해제 되지 않고 쌓이는 것으로 판단해서 이 구조를 바꿔보았습니다.

<Br>

### 1. `ImageLoader` 의 구조 변경

`ImageLoader` 는 URLSession 을 통해 Image 를 `Data` 형식으로 받아와 넘겨주고 `URLCache` 를 통해 이미 요청된 `URLRequest` 가 존재하면 메모리 또는 디스크에 저장된 Data 를 꺼내쓰는 역할을 하고 있습니다.

기존의 `ImageLoader` 는 각 `CustomAsyncImage` 마다 초기화되어 있어 굉장히 비효율적이라 생각되었습니다.
이런 구조를 갖게 된 이유는 `ImageDetailCarouselView` 에서 로딩하지 않고 `UIImage` 를 바로 넘겨주고자 데이터를 갖고 있어야 했기 때문입니다.

메모리를 줄이기 위해선 더욱 단순한 구조가 필요했고 `ImageDetailCarouselView` 로 Image 를 넘기지 않고 URLCache 에 저장된 데이터를 사용하는 방식으로 바꾸게 되면 더욱 메모리를 줄일 수 있다 판단하여 싱글톤 패턴으로 Data 를 넘겨주는 형식으로 바꾸고 `SinglePostView` 의 `loadedImage` 에 `UIImage` 를 저장하지 않는 방식으로 변경했습니다.



결과가 위에 이미 존재하지만 결과적으로 메모리의 사용량을 줄일 수 있게 되었습니다.

<Br>

### 2. 결론

`ImageDetailCarouselView` 에서 사진을 바로 보여주기 위해서 UIImage 를 바인딩 해주어야 겠다 라는 생각로 인해 `ImageLoader`에 UIImage 데이터를 갖고 있게 만든 구조가 메모리의 사용량을 증가시키는 원인이였습니다.

극적인 변화를 위해 대략 30번의 스크롤 통해 얻은 데이터 이지만 최대 메모리 사용량이 약 **1 GB** 에서 약 **292 MB** 로 **71.5 %** 줄일 수 있었습니다.
또한 스크롤 할때의 끊김 현상이나 부드러움 등 사용자 경험이 증가되는 긍정적인 결과도 얻었습니다!

<br>

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
