### PR TITLE
[Feat] #160 - 중복 초대된 유저에 대한 Alert 로직 추가

### DIFF
--- a/Treehouse/Treehouse/Global/Components/InvitationAlert.swift
+++ b/Treehouse/Treehouse/Global/Components/InvitationAlert.swift
@@ -10,6 +10,7 @@ import SwiftUI
 enum invitationState {
     case success
     case faliure
+    case duplication
 }
 struct InvitationAlert: View {
     
@@ -74,6 +75,24 @@ struct InvitationAlert: View {
             }
         case .faliure:
             Text("사용할 수 있는 초대장이 없습니다")
+                .fontWithLineHeight(fontLevel: .heading4)
+                .multilineTextAlignment(.center)
+                .padding(.bottom, 29)
+            
+            Button(action: {
+                onConfirm()
+            }) {
+                Text("확인")
+                    .fontWithLineHeight(fontLevel: .body3)
+                    .foregroundStyle(.grayscaleWhite)
+                    .padding(.vertical, 11)
+                    .frame(maxWidth: .infinity)
+                    .background(.grayscaleBlack)
+            }
+            .clipShape(RoundedRectangle(cornerRadius: 8.0))
+            
+        case .duplication:
+            Text("이미 초대가 된 멤버입니다")
                 .fontWithLineHeight(fontLevel: .heading4)
                 .multilineTextAlignment(.center)
                 .padding(.bottom, 29)

--- a/Treehouse/Treehouse/Network/Base/NetworkServiceManager.swift
+++ b/Treehouse/Treehouse/Network/Base/NetworkServiceManager.swift
@@ -85,7 +85,7 @@ final class NetworkServiceManager: NetworkServiceable {
                 
                 throw NetworkError.clientError(message: "Unknown 400 error")
                 
-            case 401...409:
+            case 401...408:
                 try await postReissueToken()
                 
                 // KeyChain 으로 저장한 accessToken 이 존재하는지?
@@ -104,6 +104,9 @@ final class NetworkServiceManager: NetworkServiceable {
                 } else {
                     throw NetworkError.jsonDecodingError
                 }
+                
+            case 409:
+                throw NetworkError.duplicationError
                 
             case 500...599:
                 throw NetworkError.serverError

--- a/Treehouse/Treehouse/Network/Error/NetworkError.swift
+++ b/Treehouse/Treehouse/Network/Error/NetworkError.swift
@@ -17,6 +17,7 @@ enum NetworkError: Error, LocalizedError {
     case userState(code: String, message: String)
     case reIssueJWT
     case unknown
+    case duplicationError
     
     var errorDescription: String? {
         switch self {
@@ -38,6 +39,8 @@ enum NetworkError: Error, LocalizedError {
             return "🔧 JWT토큰을 재발급해야 합니다 🔧"
         case .unknown:
             return "📁 알 수 없는 에러입니다. 📁"
+        case .duplicationError:
+            return "📝 중복된 유저나 전화번호 입니다. 📝"
         }
     }
 }

--- a/Treehouse/Treehouse/Presentation/Auth/InvitationScene/ViewModels/InvitationViewModel.swift
+++ b/Treehouse/Treehouse/Presentation/Auth/InvitationScene/ViewModels/InvitationViewModel.swift
@@ -26,6 +26,7 @@ final class InvitationViewModel: BaseViewModel {
     var invitationState: invitationState?
     
     var invitationTitle = "완료되었습니다."
+    var invitationError = false
     
     var errorMessage: String? = nil
     
@@ -82,10 +83,10 @@ extension InvitationViewModel {
         
         switch result {
         case .success(_):
-//            isinvitationAlert = true
             return true
         case .failure(let error):
-//            isinvitationAlert = true
+            invitationError = true
+            invitationState = .duplication
             errorMessage = error.localizedDescription
             return false
         }

--- a/Treehouse/Treehouse/Presentation/Auth/InvitationScene/Views/InviteBranchView.swift
+++ b/Treehouse/Treehouse/Presentation/Auth/InvitationScene/Views/InviteBranchView.swift
@@ -212,7 +212,7 @@ struct InviteBranchView: View {
                     switch state {
                     case .success:
                         viewModel.isinvitationAlert = false
-                    case .faliure:
+                    case .faliure, .duplication:
                         break
                     }
                 },
@@ -225,8 +225,27 @@ struct InviteBranchView: View {
                             viewModel.isinvitationAlert = false
                         }
                         viewModel.isinvitationAlert = false
-                    case .faliure:
+                    case .faliure, .duplication:
                         viewModel.isinvitationAlert = false
+                    }
+                })
+            }
+        }
+        .topLevelAlert(isPresented: $viewModel.invitationError) {
+            if let state = viewModel.invitationState {
+                InvitationAlert(invitationState: .duplication, memberName: viewModel.invitedMember, onCancel: {
+                    switch state {
+                    case .success:
+                        viewModel.isinvitationAlert = false
+                    case .faliure, .duplication:
+                        break
+                    }
+                }, onConfirm: {
+                    switch state {
+                    case .duplication:
+                        viewModel.invitationError = false
+                    default:
+                        break
                     }
                 })
             }


### PR DESCRIPTION
## 📟 관련 이슈
- Resolved: #160 

<br>

## 👷 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
- 이미 초대된 유저를 다시 초대했을 때 중복 alert 을 띄우는 로직 추가

<br>

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "https://github.com/user-attachments/assets/1aca4e8c-e5f9-4972-8bb7-a15492da8baa" width ="400">|

<br>

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
