### PR TITLE
[Fix] #162 - DetailView 에서 게시글 수정 안됨 현상 해결

### DIFF
--- a/Treehouse/Treehouse/Presentation/Feed/FeedScene/Views/EditPostPopupView.swift
+++ b/Treehouse/Treehouse/Presentation/Feed/FeedScene/Views/EditPostPopupView.swift
@@ -25,7 +25,7 @@ struct EditPostPopupView: View {
     let postId: Int
     let memberProfile: MemberProfileEntity
     let postImageURLs: [String]
-    
+
     // MARK: - View
     
     var body: some View {
@@ -50,6 +50,8 @@ struct EditPostPopupView: View {
 
                             TextEditor(text: $postContent)
                                 .fontWithLineHeight(fontLevel: .body3)
+                                .scrollContentBackground(.hidden)
+                                .background(.grayscaleWhite)
                                 .focused($isFocused)
                                 .onAppear {
                                     DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
@@ -57,8 +59,6 @@ struct EditPostPopupView: View {
                                     }
                                 }
                                 .padding(.bottom, 15)
-                                .zIndex(1)
-
                             
                             if postImageURLs.count == 1 {
                                 CustomAsyncImage(url: postImageURLs.first ?? "",
@@ -86,13 +86,12 @@ struct EditPostPopupView: View {
                     .padding(16)
                 }
             }
-            
-            if isCancelPopupShowing {
-                cancleEditPopupView
-            }
         }
         .onAppear {
             UIApplication.shared.hideKeyboard()
+        }
+        .topLevelAlert(isPresented: $isCancelPopupShowing) {
+            cancleEditPopupView
         }
     }
 }
@@ -128,7 +127,6 @@ extension EditPostPopupView {
                     if updateFeedPostViewModel.isUpdatePost {
                         sheetActionViewModel.isEditPostPopupShowing.toggle()
                         feedViewModel.modifyPostContent = (postId, postContent)
-//                        feedViewModel.isModifyPostContent.toggle()
                     }
                 }
             }) {

--- a/Treehouse/Treehouse/Presentation/Feed/FeedScene/Views/PostDetailView.swift
+++ b/Treehouse/Treehouse/Presentation/Feed/FeedScene/Views/PostDetailView.swift
@@ -44,7 +44,8 @@ struct PostDetailView: View {
                     VStack {
                         if let _ = feedViewModel.currentPostId, let postDetailData = postDetailViewModel.detailFeedListData {
                             
-                            SinglePostView(sentTime: postDetailData.postedAt,
+                            SinglePostView(postId: postDetailData.postId,
+                                           sentTime: postDetailData.postedAt,
                                            postContent: postDetailData.context,
                                            postImageURLs: postDetailData.pictureUrlList,
                                            memberProfile: postDetailData.memberProfile,

--- a/Treehouse/Treehouse/Presentation/Feed/FeedScene/Views/SinglePostView.swift
+++ b/Treehouse/Treehouse/Presentation/Feed/FeedScene/Views/SinglePostView.swift
@@ -30,7 +30,7 @@ struct SinglePostView: View {
     
     // MARK: - Property
     
-    let postId: Int?
+    let postId: Int
     let sentTime: String
     var postContent: String
     let postImageURLs: [String]
@@ -39,17 +39,8 @@ struct SinglePostView: View {
     
     // MARK:  - init
     
-    init(postId: Int?, sentTime: String, postContent: String, postImageURLs: [String], memberProfile: MemberProfileEntity, postType: PostType) {
+    init(postId: Int, sentTime: String, postContent: String, postImageURLs: [String], memberProfile: MemberProfileEntity, postType: PostType) {
         self.postId = postId
-        self.sentTime = sentTime
-        self.postContent = postContent
-        self.postImageURLs = postImageURLs
-        self.memberProfile = memberProfile
-        self.postType = postType
-    }
-    
-    init(sentTime: String, postContent: String, postImageURLs: [String], memberProfile: MemberProfileEntity, postType: PostType) {
-        self.postId = nil
         self.sentTime = sentTime
         self.postContent = postContent
         self.postImageURLs = postImageURLs


### PR DESCRIPTION
## 📟 관련 이슈
- Resolved: #162 

## 👷 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
- DetailView 에서 게시글이 수정 안되는 현상을 해결 
- 게시글 수정 취소 시 나타는 Alert 로직 수정 ( 게시글 수정 뷰에만 적용되던 배경흐림 현상 -> 화면 전체 )
- TextEditor 의 배경색 변경

<br>

## 📸 스크린샷
|기능|변경 전|변경 후|
|:--:|:--:|:--:|
|Img|<img src = "https://github.com/user-attachments/assets/23af6c33-78c0-4cb0-8bbc-c6c06d1b4aa4" width ="250">|<img src = "https://github.com/user-attachments/assets/ba7c2119-3ca3-4a71-9e30-99dcfcf5e21b" width ="250">|

<br>

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
