### PR TITLE
[Fix] #164 - 초대장 관련 이미지 로직 수정

### DIFF
--- a/Treehouse/Treehouse/Global/Components/InvitationView.swift
+++ b/Treehouse/Treehouse/Global/Components/InvitationView.swift
@@ -44,8 +44,14 @@ struct InvitationView: View {
                 treehouseTitleView
                     .padding(.top, invitationType == .first ? SizeLiterals.Screen.screenHeight * 26.44 / 852 : SizeLiterals.Screen.screenHeight * 15 / 852)
                 
-                invitationView
-                    .padding(.bottom, SizeLiterals.Screen.screenHeight * (46)/852)
+                switch invitationType {
+                case .first:
+                    firstInvitationView
+                        .padding(.bottom, SizeLiterals.Screen.screenHeight * (46)/852)
+                case .received:
+                    receivedInvitationView
+                        .padding(.bottom, SizeLiterals.Screen.screenHeight * (46)/852)
+                }
                 
                 HStack(spacing: 12) {
                     Button(action: {
@@ -116,7 +122,7 @@ extension InvitationView {
     }
     
     @ViewBuilder
-    var invitationView: some View {
+    var firstInvitationView: some View {
         VStack(spacing: 0) {
             CustomAsyncImage(url: viewModel.senderProfileImageUrl,
                              type: .treehouseImage,
@@ -152,6 +158,44 @@ extension InvitationView {
             }
         }
     }
+    
+    @ViewBuilder
+    var receivedInvitationView: some View {
+        VStack(spacing: 0) {
+            CustomAsyncImage(url: viewModel.senderProfileImageUrl,
+                             type: .treehouseImage,
+                             width: 98.56, height: 98.56)
+            .clipShape(Circle())
+            .padding(.top, SizeLiterals.Screen.screenHeight * 27.27 / 852)
+            .padding(.bottom, SizeLiterals.Screen.screenHeight * 20.72 / 852)
+            
+            Text(treehouseName)
+                .fontWithLineHeight(fontLevel: .heading2)
+                .foregroundStyle(.treeBlack)
+                .padding(.bottom, 6)
+            
+            HStack(spacing: 0) {
+                Text("\(invitedMember)님")
+                    .fontWithLineHeight(fontLevel: .body2)
+                Text("이 당신을 초대했습니다.")
+                    .fontWithLineHeight(fontLevel: .body3)
+            }
+            .foregroundStyle(.gray8)
+            .padding(.bottom, 18)
+            
+            HStack(spacing: 0) {
+                HStack(spacing: -3) {
+                    ForEach(0..<iterater, id: \.self) { index in
+                        memberProfileImage(index, memberNum - 2)
+                    }
+                }
+                .padding(.trailing, 8)
+                
+                Text("\(memberNum)명의 멤버들이 함께하고 있어요.")
+                    .fontWithLineHeight(fontLevel: .body5)
+            }
+        }
+    }
 
     @ViewBuilder
     func memberProfileImage(_ index: Int, _ count: Int) -> some View {
@@ -167,12 +211,23 @@ extension InvitationView {
                     .foregroundStyle(.grayscaleWhite)
             }
         } else {
-            CustomAsyncImage(url: viewModel.memberProfileImages[index] ?? "",
-                             type: .postMemberProfileImage,
-                             width: 29, height: 29)
-            .clipShape(Circle())
-            .overlay {
-                Circle().stroke(.grayscaleWhite, lineWidth: 1.5)
+            switch invitationType {
+            case .first:
+                CustomAsyncImage(url: viewModel.memberProfileImages[index] ?? "",
+                                 type: .postMemberProfileImage,
+                                 width: 29, height: 29)
+                .clipShape(Circle())
+                .overlay {
+                    Circle().stroke(.grayscaleWhite, lineWidth: 1.5)
+                }
+            case .received:
+                CustomAsyncImage(url: memberProfileUrls[index] ?? "",
+                                 type: .postMemberProfileImage,
+                                 width: 29, height: 29)
+                .clipShape(Circle())
+                .overlay {
+                    Circle().stroke(.grayscaleWhite, lineWidth: 1.5)
+                }
             }
         }
     }

--- a/Treehouse/Treehouse/Presentation/Auth/InvitationScene/ViewModels/ReceivedInvitationViewModel.swift
+++ b/Treehouse/Treehouse/Presentation/Auth/InvitationScene/ViewModels/ReceivedInvitationViewModel.swift
@@ -39,13 +39,9 @@ extension ReceivedInvitationViewModel {
         
         switch result {
         case .success(let response):
-            await MainActor.run {
-                receivedInvitations = response.invitations
-            }
+            receivedInvitations = response.invitations
         case .failure(let error):
-            await MainActor.run {
-                self.errorMessage = error.localizedDescription
-            }
+            self.errorMessage = error.localizedDescription
         }
     }
     
@@ -58,9 +54,7 @@ extension ReceivedInvitationViewModel {
         case .success(_):
             return true
         case .failure(let error):
-            await MainActor.run {
-                self.errorMessage = error.localizedDescription
-            }
+            self.errorMessage = error.localizedDescription
             return false
         }
     }

--- a/Treehouse/Treehouse/Presentation/Auth/RegisterScene/Views/ReceivedFirstInvitaionView.swift
+++ b/Treehouse/Treehouse/Presentation/Auth/RegisterScene/Views/ReceivedFirstInvitaionView.swift
@@ -78,12 +78,7 @@ struct ReceivedFirstInvitaionView: View {
         .task {
             await viewModel.checkInvitations()
         }
-        .onAppear {
-            let appearance = UINavigationBarAppearance()
-            appearance.backgroundColor = UIColor.gray1
-            appearance.shadowColor = .clear // 하단 선 제거
-            UINavigationBar.appearance().scrollEdgeAppearance = appearance
-        }
+        .toolbarBackground(.gray1)
         .onDisappear {
             print("ReceivedFirstInvitationView disappeared")
         }


### PR DESCRIPTION
## 📟 관련 이슈
- Resolved: #164 

## 👷 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
- 공용으로 사용하는 `InvitationView` 에서 처음으로 가입한 유저와 트리하우스 초대장을 받은 유저를 분리한 로직 추가 
- `ReceivedFirstInvitaionView` 의 `ToolBar` 색상 변경

## 🚨 참고 사항
<!-- 참고 사항을 적어주세요. 없으면 지워주세요. -->
- `InvitationView` 에서 invitationType 에 따른 UI 를 분리하였습니다
    - 처음으로 가입하는 유저는 `firstInvitationView` 
    - 초대장을 받은 유저는 `receivedInvitationView` 


## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
