### PR TITLE
[Feat] #166 - 초대 받은 초대장이 없을 때의 UI 구현

### DIFF
--- a/Treehouse/Treehouse/Presentation/Auth/InvitationScene/ViewModels/ReceivedInvitationViewModel.swift
+++ b/Treehouse/Treehouse/Presentation/Auth/InvitationScene/ViewModels/ReceivedInvitationViewModel.swift
@@ -40,6 +40,7 @@ extension ReceivedInvitationViewModel {
         switch result {
         case .success(let response):
             receivedInvitations = response.invitations
+            viewState = receivedInvitations.isEmpty ? .unInvitation : .invitation
         case .failure(let error):
             self.errorMessage = error.localizedDescription
         }


### PR DESCRIPTION
## 📟 관련 이슈
- Resolved: #166 

## 👷 작업한 내용
<!-- 작업한 내용을 적어주세요. -->
- 초대 받은 초대장이 없을 때 보여줄 UI 를 구현

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|GIF|<img src = "https://github.com/user-attachments/assets/c5520726-55bf-44ba-aa1b-60584785e0b9" width ="400">|

## 🚨 참고 사항
<!-- 참고 사항을 적어주세요. 없으면 지워주세요. -->
- 기존에 초대받은 초대장이 없을 때의 UI 는 구현이 되어있었지만 View 로직에 추가하지 않아 다음과 같이 구현했습니다.

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
